### PR TITLE
feat: port tg emissives

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -110,6 +110,7 @@
 #include "code\_helpers\game.dm"
 #include "code\_helpers\global_lists.dm"
 #include "code\_helpers\icons.dm"
+#include "code\_helpers\lighting.dm"
 #include "code\_helpers\lists.dm"
 #include "code\_helpers\logging.dm"
 #include "code\_helpers\maths.dm"

--- a/code/__defines/__renderer.dm
+++ b/code/__defines/__renderer.dm
@@ -164,6 +164,10 @@
 
 #define ABOVE_HUD_PLANE                7
 
+/// This plane masks out lighting to create an "emissive" effect, ie for glowing lights in otherwise dark areas.
+#define EMISSIVE_PLANE 8
+#define EMISSIVE_RENDER_TARGET "*EMISSIVE_PLANE"
+
 //-------------------- Rendering ---------------------
 
 /// Semantics - The final compositor or a filter effect renderer

--- a/code/__defines/_renderer.dm
+++ b/code/__defines/_renderer.dm
@@ -338,6 +338,9 @@ GLOBAL_LIST_EMPTY(zmimic_renderers)
  * The layers for the emissive overlays and emissive blockers cause them to mask eachother similar to normal BYOND objects.
  * A color matrix filter is applied to the emissive plane to mask out anything that isn't whatever the emissive color is.
  * This is then used to alpha mask the lighting plane.
+ *
+ * This works best if emissive overlays applied only to objects that emit light,
+ * since luminosity=0 turfs may not be rendered.
  */
 /atom/movable/renderer/emissive
 	name = "Emissive"

--- a/code/__defines/_renderer.dm
+++ b/code/__defines/_renderer.dm
@@ -195,6 +195,14 @@ GLOBAL_LIST_EMPTY(zmimic_renderers)
 	)
 	mouse_opacity = MOUSE_OPACITY_UNCLICKABLE
 
+/atom/movable/renderer/lighting/Initialize()
+	. = ..()
+	filters += filter(
+		type = "alpha",
+		render_source = EMISSIVE_RENDER_TARGET,
+		flags = MASK_INVERSE
+	)
+
 /// Draws visuals that should not be affected by darkness.
 /atom/movable/renderer/above_lighting
 	name = "Above Lighting"
@@ -320,3 +328,27 @@ GLOBAL_LIST_EMPTY(zmimic_renderers)
 	. = ..()
 	filters += filter(type = "displace", render_source = "*warp", size = 5)
 	filters += filter(type = "displace", render_source = HEAT_COMPOSITE_TARGET, size = 2.5)
+
+/*!
+ * This system works by exploiting BYONDs color matrix filter to use layers to handle emissive blockers.
+ *
+ * Emissive overlays are pasted with an atom color that converts them to be entirely some specific color.
+ * Emissive blockers are pasted with an atom color that converts them to be entirely some different color.
+ * Emissive overlays and emissive blockers are put onto the same plane.
+ * The layers for the emissive overlays and emissive blockers cause them to mask eachother similar to normal BYOND objects.
+ * A color matrix filter is applied to the emissive plane to mask out anything that isn't whatever the emissive color is.
+ * This is then used to alpha mask the lighting plane.
+ */
+/atom/movable/renderer/emissive
+	name = "Emissive"
+	group = RENDER_GROUP_NONE
+	plane = EMISSIVE_PLANE
+	mouse_opacity = MOUSE_OPACITY_UNCLICKABLE
+	render_target_name = EMISSIVE_RENDER_TARGET
+
+/atom/movable/renderer/emissive/Initialize()
+	. = ..()
+	filters += filter(
+		type = "color",
+		color = GLOB.em_mask_matrix
+	)

--- a/code/__defines/lighting.dm
+++ b/code/__defines/lighting.dm
@@ -84,3 +84,43 @@
 #define AREA_LIGHTING_WARM		"warm"
 #define AREA_LIGHTING_COOL		"cool"
 #define AREA_LIGHTING_DEFAULT	"default" // For light replacers, defaults to whatever the area is set to. For areas, uses the initial lighting value from the light bulb itself.
+
+// Emissive blocking.
+
+/// For anything that doesn't change outline or opaque area much or at all.
+#define EMISSIVE_BLOCK_GENERIC 1
+/// Uses a dedicated render_target object to copy the entire appearance in real time to the blocking layer. For things that can change in appearance a lot from the base state, like humans.
+#define EMISSIVE_BLOCK_UNIQUE 2
+
+/// The color applied to all emissive overlays.
+#define EMISSIVE_COLOR list( \
+	0, 0, 0, 0, \
+	0, 0, 0, 0, \
+	0, 0, 0, 0, \
+	0, 0, 0, 1, \
+	1, 1, 1, 0)
+/// A globaly cached version of [EMISSIVE_COLOR] for quick access.
+GLOBAL_LIST_INIT(emissive_color, EMISSIVE_COLOR)
+
+/// The color applied to all emissive blockers. Is meant to be the exact opposite of the EMMISIVE_COLOR
+#define EM_BLOCK_COLOR list(\
+	0, 0, 0, 0, \
+	0, 0, 0, 0, \
+	0, 0, 0, 0, \
+	0, 0, 0, 1, \
+	0, 0, 0, 0)
+/// A globaly cached version of [EM_BLOCK_COLOR] for quick access.
+GLOBAL_LIST_INIT(em_block_color, EM_BLOCK_COLOR)
+
+/// The color matrix used to mask out emissive blockers on the emissive plane. Alpha should default to zero, be solely dependent on the RGB value of [EMISSIVE_COLOR], and be independant of the RGB value of [EM_BLOCK_COLOR].
+#define EM_MASK_MATRIX list( \
+	0, 0, 0, 1/3,\
+	0, 0, 0, 1/3,\
+	0, 0, 0, 1/3,\
+	0, 0, 0, 0,  \
+	1, 1, 1, 0)
+/// A globaly cached version of [EM_MASK_MATRIX] for quick access.
+GLOBAL_LIST_INIT(em_mask_matrix, EM_MASK_MATRIX)
+
+/// A set of appearance flags applied to all emissive and emissive blocker overlays.
+#define EMISSIVE_APPEARANCE_FLAGS (KEEP_APART|KEEP_TOGETHER|RESET_COLOR|NO_CLIENT_COLOR)

--- a/code/_helpers/lighting.dm
+++ b/code/_helpers/lighting.dm
@@ -1,0 +1,31 @@
+/// Produces a mutable appearance glued to the [EMISSIVE_PLANE] dyed to be the [EMISSIVE_COLOR].
+/proc/emissive_appearance(icon, icon_state = "", layer = FLOAT_LAYER, alpha = 255, appearance_flags = 0)
+	var/mutable_appearance/appearance = mutable_appearance(
+		icon = icon,
+		icon_state = icon_state,
+		layer = layer,
+		plane = EMISSIVE_PLANE,
+		flags = appearance_flags|EMISSIVE_APPEARANCE_FLAGS
+	)
+	appearance.alpha = alpha
+	appearance.blend_mode = BLEND_OVERLAY
+	appearance.color = GLOB.emissive_color
+	return appearance
+
+/// Produces a mutable appearance glued to the [EMISSIVE_PLANE] dyed to be the [EM_BLOCK_COLOR].
+/proc/emissive_blocker(icon, icon_state = "", layer = FLOAT_LAYER, alpha = 255, appearance_flags = 0, source = null)
+	var/mutable_appearance/appearance = mutable_appearance(
+		icon = icon,
+		icon_state = icon_state,
+		layer = layer,
+		plane = EMISSIVE_PLANE,
+		flags = appearance_flags|EMISSIVE_APPEARANCE_FLAGS
+	)
+	appearance.alpha = alpha
+	appearance.blend_mode = BLEND_OVERLAY
+	appearance.color = GLOB.em_block_color
+	if(source)
+		appearance.render_source = source
+		// Since only render_target handles transform we don't get any applied transform "stacking"
+		appearance.appearance_flags |= RESET_TRANSFORM
+	return appearance

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -29,6 +29,8 @@
 	var/climb_speed_mult = 1
 	/// Bitflag (Any of `INIT_*`). Flags for special/additional handling of the `Initialize()` chain. See `code\__defines\misc.dm`.
 	var/init_flags = EMPTY_BITFIELD
+	/// overlays managed by update_overlays() to prevent removing overlays that weren't added by the same proc
+	var/list/managed_overlays
 
 /atom/New(loc, ...)
 	SHOULD_CALL_PARENT(TRUE) // Ensures atoms don't unintentionally skip initialization by not calling parent in New()
@@ -430,6 +432,14 @@
 		return
 	on_update_icon(arglist(args))
 
+	var/list/new_overlays = update_overlays()
+	if(managed_overlays)
+		overlays -= managed_overlays
+		managed_overlays = null
+	if(length(new_overlays))
+		managed_overlays = new_overlays
+		overlays += new_overlays
+
 /**
  * Handler for updating the atom's icon and overlay states. Generally, all changes to `overlays`, `underlays`, `icon`,
  * `icon_state`, `item_state`, etc should be contained in here.
@@ -438,6 +448,11 @@
  */
 /atom/proc/on_update_icon()
 	return
+
+/** Updates the overlays of the atom */
+/atom/proc/update_overlays()
+	SHOULD_CALL_PARENT(1)
+	. = list()
 
 /**
  * Called when an explosion affects the atom.

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -37,34 +37,11 @@
 	if (!isnull(config.glide_size))
 		glide_size = config.glide_size
 	. = ..()
-	update_emissive_block()
-
-/atom/movable/proc/update_emissive_block()
-	if(!blocks_emissive)
-		return
-	if (blocks_emissive == EMISSIVE_BLOCK_GENERIC)
-		var/mutable_appearance/gen_emissive_blocker = emissive_blocker(
-			icon = icon,
-			icon_state = icon_state,
-			alpha = alpha,
-			appearance_flags = appearance_flags
-		)
-		gen_emissive_blocker.dir = dir
-		underlays += gen_emissive_blocker
-		return
-	if(blocks_emissive == EMISSIVE_BLOCK_UNIQUE)
-		if(!em_block && !QDELETED(src))
-			// The atom must use the KEEP_TOGETHER flag to have its overlays/underlays included in the render_target image.
-			appearance_flags |= KEEP_TOGETHER
-			render_target = ref(src)
-			var/mutable_appearance/gen_emissive_blocker = emissive_blocker(
-				icon = icon,
-				appearance_flags = appearance_flags,
-				source = render_target
-			)
-			em_block = gen_emissive_blocker
-		underlays += em_block
-		return
+	var/emissive_block = update_emissive_block()
+	if(emissive_block)
+		overlays += emissive_block
+		// Since this overlay is managed by update_overlays proc
+		LAZYADD(managed_overlays, emissive_block)
 
 /atom/movable/Destroy()
 
@@ -95,6 +72,37 @@
 		QDEL_NULL(em_block)
 
 	return ..()
+
+/atom/movable/proc/update_emissive_block()
+	if(!blocks_emissive)
+		return
+	if (blocks_emissive == EMISSIVE_BLOCK_GENERIC)
+		var/mutable_appearance/gen_emissive_blocker = emissive_blocker(
+			icon = icon,
+			icon_state = icon_state,
+			alpha = alpha,
+			appearance_flags = appearance_flags
+		)
+		gen_emissive_blocker.dir = dir
+		return gen_emissive_blocker
+	if(blocks_emissive == EMISSIVE_BLOCK_UNIQUE)
+		if(!em_block && !QDELETED(src))
+			// The atom must use the KEEP_TOGETHER flag to have its overlays/underlays included in the render_target image.
+			appearance_flags |= KEEP_TOGETHER
+			render_target = ref(src)
+			var/mutable_appearance/gen_emissive_blocker = emissive_blocker(
+				icon = icon,
+				appearance_flags = appearance_flags,
+				source = render_target
+			)
+			em_block = gen_emissive_blocker
+		return em_block
+
+/atom/movable/update_overlays()
+	. = ..()
+	var/emissive_block = update_emissive_block()
+	if(emissive_block)
+		. += emissive_block
 
 /atom/movable/Bump(atom/A, yes)
 	if(!QDELETED(throwing))

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -28,11 +28,43 @@
 	/// The icon height this movable expects to have by default.
 	var/icon_height = 32
 
+	/// Either FALSE, [EMISSIVE_BLOCK_GENERIC], or [EMISSIVE_BLOCK_UNIQUE]
+	var/blocks_emissive = FALSE
+	///Internal holder for emissive blocker object, do not use directly use blocks_emissive
+	var/mutable_appearance/em_block
 
 /atom/movable/Initialize()
 	if (!isnull(config.glide_size))
 		glide_size = config.glide_size
 	. = ..()
+	update_emissive_block()
+
+/atom/movable/proc/update_emissive_block()
+	if(!blocks_emissive)
+		return
+	if (blocks_emissive == EMISSIVE_BLOCK_GENERIC)
+		var/mutable_appearance/gen_emissive_blocker = emissive_blocker(
+			icon = icon,
+			icon_state = icon_state,
+			alpha = alpha,
+			appearance_flags = appearance_flags
+		)
+		gen_emissive_blocker.dir = dir
+		underlays += gen_emissive_blocker
+		return
+	if(blocks_emissive == EMISSIVE_BLOCK_UNIQUE)
+		if(!em_block && !QDELETED(src))
+			// The atom must use the KEEP_TOGETHER flag to have its overlays/underlays included in the render_target image.
+			appearance_flags |= KEEP_TOGETHER
+			render_target = ref(src)
+			var/mutable_appearance/gen_emissive_blocker = emissive_blocker(
+				icon = icon,
+				appearance_flags = appearance_flags,
+				source = render_target
+			)
+			em_block = gen_emissive_blocker
+		underlays += em_block
+		return
 
 /atom/movable/Destroy()
 
@@ -58,6 +90,9 @@
 
 	if(ismob(virtual_mob))
 		QDEL_NULL(virtual_mob)
+
+	if(em_block)
+		QDEL_NULL(em_block)
 
 	return ..()
 

--- a/code/game/machinery/computer/computer.dm
+++ b/code/game/machinery/computer/computer.dm
@@ -43,6 +43,7 @@
 
 /obj/machinery/computer/on_update_icon()
 	overlays.Cut()
+	underlays.Cut()
 	icon = initial(icon)
 	icon_state = initial(icon_state)
 
@@ -70,6 +71,7 @@
 		overlays += image(icon,"[icon_state]_broken", overlay_layer)
 	else
 		overlays += get_screen_overlay()
+		underlays += emissive_appearance(icon, icon_screen)
 
 	overlays += get_keyboard_overlay()
 

--- a/code/game/machinery/computer/computer.dm
+++ b/code/game/machinery/computer/computer.dm
@@ -43,12 +43,10 @@
 
 /obj/machinery/computer/on_update_icon()
 	overlays.Cut()
-	underlays.Cut()
 	icon = initial(icon)
 	icon_state = initial(icon_state)
 
 	if(reason_broken & MACHINE_BROKEN_NO_PARTS)
-		set_light(0)
 		icon = 'icons/obj/computer.dmi'
 		icon_state = "wired"
 		var/screen = get_component_of_type(/obj/item/stock_parts/console_screen)
@@ -60,18 +58,14 @@
 		return
 
 	if(!is_powered())
-		set_light(0)
 		if(icon_keyboard)
 			overlays += image(icon,"[icon_keyboard]_off", overlay_layer)
 		return
-	else
-		set_light(light_max_bright_on, light_inner_range_on, light_outer_range_on, 2, light_color)
 
 	if(MACHINE_IS_BROKEN(src))
 		overlays += image(icon,"[icon_state]_broken", overlay_layer)
 	else
 		overlays += get_screen_overlay()
-		underlays += emissive_appearance(icon, icon_screen)
 
 	overlays += get_keyboard_overlay()
 
@@ -86,6 +80,24 @@
 	// Adds line breaks
 	text = replacetext(text, "\n", "<BR>")
 	return text
+
+/**
+Makes the computer emit light if the screen is on.
+Returns TRUE if the screen is on, otherwise FALSE.
+*/
+/obj/machinery/computer/proc/update_glow()
+	if(operable())
+		set_light(light_max_bright_on, light_inner_range_on, light_outer_range_on, 2, light_color)
+		return TRUE
+	else
+		set_light(0)
+		return FALSE
+
+/obj/machinery/computer/update_overlays()
+	. = ..()
+	var/screen_is_glowing = update_glow()
+	if(screen_is_glowing)
+		. += emissive_appearance(icon, icon_screen)
 
 /obj/machinery/computer/dismantle(mob/user)
 	if(MACHINE_IS_BROKEN(src))

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -3,6 +3,7 @@
 	icon = 'icons/obj/items.dmi'
 	w_class = ITEM_SIZE_NORMAL
 	mouse_drag_pointer = MOUSE_ACTIVE_POINTER
+	blocks_emissive = EMISSIVE_BLOCK_GENERIC
 
 	var/image/blood_overlay = null //this saves our blood splatter overlay, which will be processed not to go over the edges of the sprite
 	var/randpixel = 6

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -3,6 +3,8 @@
 	mob_push_flags = ~HEAVY
 	mob_swap_flags = ~HEAVY
 
+	blocks_emissive = EMISSIVE_BLOCK_UNIQUE
+
 	/// The style of head hair applied to this mob
 	var/head_hair_style = "Bald"
 

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -13,6 +13,8 @@
 	mob_push_flags = ~HEAVY //trundle trundle
 	skillset = /datum/skillset/silicon/robot
 
+	blocks_emissive = EMISSIVE_BLOCK_UNIQUE
+
 	var/lights_on = FALSE
 	var/used_power_this_tick = 0
 	var/power_efficiency = 1

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/parrot.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/parrot.dm
@@ -35,6 +35,8 @@
 	pass_flags = PASS_FLAG_TABLE
 	mob_size = MOB_SMALL
 
+	blocks_emissive = EMISSIVE_BLOCK_UNIQUE
+
 	speak_emote = list("squawks","says","yells")
 
 	natural_weapon = /obj/item/natural_weapon/beak

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -7,6 +7,8 @@
 	animate_movement = 2
 	movable_flags = MOVABLE_FLAG_PROXMOVE
 
+	blocks_emissive = EMISSIVE_BLOCK_GENERIC
+
 	virtual_mob = /mob/observer/virtual/mob
 
 	movement_handlers = list(

--- a/code/modules/modular_computers/computers/subtypes/dev_console.dm
+++ b/code/modules/modular_computers/computers/subtypes/dev_console.dm
@@ -43,15 +43,6 @@
 		os.ui_interact(user)
 	return TRUE
 
-/obj/machinery/computer/modular/on_update_icon()
-	. = ..()
-	var/datum/extension/interactive/ntos/os = get_extension(src, /datum/extension/interactive/ntos)
-	if(os)
-		if(os.on)
-			set_light(light_max_bright_on, light_inner_range_on, light_outer_range_on, 2, light_color)
-		else
-			set_light(0)
-
 /obj/machinery/computer/modular/get_screen_overlay()
 	var/datum/extension/interactive/ntos/os = get_extension(src, /datum/extension/interactive/ntos)
 	if(os)

--- a/code/modules/overmap/ships/computers/helm.dm
+++ b/code/modules/overmap/ships/computers/helm.dm
@@ -384,9 +384,7 @@ LEGACY_RECORD_STRUCTURE(all_waypoints, waypoint)
 	machine_desc = "A compact, slimmed-down version of the navigation console."
 
 /obj/machinery/computer/ship/navigation/telescreen/on_update_icon()
-	if(reason_broken & MACHINE_BROKEN_NO_PARTS || !is_powered() || MACHINE_IS_BROKEN(src))
+	if(inoperable())
 		icon_state = "tele_off"
-		set_light(0)
 	else
 		icon_state = "tele_nav"
-		set_light(light_max_bright_on, light_inner_range_on, light_outer_range_on, 2, light_color)

--- a/code/modules/power/sensors/sensor_monitoring.dm
+++ b/code/modules/power/sensors/sensor_monitoring.dm
@@ -8,7 +8,7 @@
 	desc = "Computer designed to remotely monitor power levels."
 	icon = 'icons/obj/computer.dmi'
 	icon_keyboard = "power_key"
-	icon_screen = "power"
+	icon_screen = "power_screen"
 	light_color = "#ffcc33"
 	machine_name = "power monitoring console"
 	machine_desc = "Allows for a detailed and thorough readout of the area's power generation and consumption, listed by area."
@@ -27,19 +27,6 @@
 	if(alert != alerting)
 		alerting = !alerting
 		update_icon()
-
-// Updates icon of this computer according to current status.
-/obj/machinery/computer/power_monitor/on_update_icon()
-	if(MACHINE_IS_BROKEN(src))
-		icon_state = "powerb"
-		return
-	if(!is_powered())
-		icon_state = "power0"
-		return
-	if(alerting)
-		icon_state = "power_alert"
-		return
-	icon_state = "power"
 
 // On creation automatically connects to active sensors. This is delayed to ensure sensors already exist.
 /obj/machinery/computer/power_monitor/New()


### PR DESCRIPTION
ТЕКСТ ВЫШЕ НУЖНО УДАЛИТЬ. <!-- УДАЛИЛ--> (lul)

Портирована с TG возможность создания картинок, игнорирующих темноту (emissives).
Экраны компьютеров теперь "светятся" в темноте.

![emis](https://user-images.githubusercontent.com/79848183/220368871-a581ad71-ef44-4273-84c3-a64bc7cdd023.png)

Также портирован прок update_overlays, чтобы не было мучительно больно обновлять оверлеи, нужные для этих эмиссивов.

Ишью нету.

<details>
<summary>Чейнджлог</summary>

```yml
🆑
experiment: Добавил картинки, игнорирующие темноту. Прикрутил к дисплеям компов.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
<!-- - [x] Я ебал рот вашего пулл реквест темплейта. -->