### PR TITLE
Tweak: Кнопка try again в незагрузившемся чате

### DIFF
--- a/code/modules/goonchat/browserOutput.dm
+++ b/code/modules/goonchat/browserOutput.dm
@@ -99,6 +99,9 @@ GLOBAL_DATUM_INIT(iconCache, /savefile, new("data/iconCache.sav"))
 			swaptodarkmode()
 		if ("swaptolightmode")
 			swaptolightmode()
+		if ("try_again")
+			loaded = FALSE
+			start()
 	if(data)
 		ehjax_send(data = data)
 
@@ -115,6 +118,7 @@ GLOBAL_DATUM_INIT(iconCache, /savefile, new("data/iconCache.sav"))
 	sendClientData()
 	syncRegex()
 	legacy_chat(owner, SPAN_DANGER("Failed to load fancy chat. Some features won't work.")) // do NOT convert to to_chat()
+	legacy_chat(owner, SPAN_DANGER("Shall we <a href='?_src_=chat&proc=try_again'>try again</a>?")) // do NOT convert to to_chat()
 
 
 /datum/chatOutput/proc/showChat()


### PR DESCRIPTION
Добавляет кнопку try again в чат, видимую в случае если гунчат не загрузился

Closes #23

<details>
<summary>Чейнджлог</summary>

```yml
🆑
tweak: Добавил кнопку try again в легаси чат, видимую в случае если гунчат не загрузился
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
