### PR TITLE
Scrap return

### DIFF
--- a/mods/machinery/scrap_compactor/scrap_refine.dm
+++ b/mods/machinery/scrap_compactor/scrap_refine.dm
@@ -1,3 +1,17 @@
+/obj/item/crush_act() // This is how we get unrefined scrap in compactor
+	playsound(src.loc, 'sound/items/Welder.ogg', 50, 1)
+	for(var/i in 1 to w_class)
+		new /obj/item/scrap_lump(loc)
+	for(var/obj/item/I in contents)
+		I.forceMove(loc)
+		I.crush_act()
+	..()
+
+/obj/item/organ/crush_act() // prevent gaining scrap from organs. Yep this is... so uncivilised
+	ex_act(1)
+	if(!QDELETED(src))
+		qdel(src)
+
 /obj/structure/scrap_cube
 	name = "compressed scrap"
 	desc = "A cube made of scrap compressed with hydraulic clamp."


### PR DESCRIPTION
ТЕКСТ ВЫШЕ НУЖНО УДАЛИТЬ.

Вернул генерацию мусора при давлении всего и вся в компакторе

Ишшью нет

Это багфикс, какой ченджлог... Теперь ты довольна, машина?

```yml
🆑
bugfix: Пофиксил отсутствие unrefined scrap в компакторе после удачного запуска.
/🆑
```

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
