### PR TITLE
Fix: Changelog checker

### DIFF
--- a/tools/changelog/sierra_check_changelog.py
+++ b/tools/changelog/sierra_check_changelog.py
@@ -99,4 +99,9 @@ if write_cl['changes']:
     exit(0)
 else:
     print("No CL changes detected!")
+    # add invalid, remove valid
+    if not has_invalid_label:
+        pr.add_to_labels(CL_INVALID)
+    if has_valid_label:
+        pr.remove_from_labels(CL_VALID)
     exit(1)


### PR DESCRIPTION
Теперь если CL есть, а изменений нет - вешается лейбочка

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
