### PR TITLE
FEAT: SSOvermap

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -247,6 +247,7 @@
 #include "code\controllers\subsystems\processing\icon_updates.dm"
 #include "code\controllers\subsystems\processing\nano.dm"
 #include "code\controllers\subsystems\processing\obj.dm"
+#include "code\controllers\subsystems\processing\overmap.dm"
 #include "code\controllers\subsystems\processing\processing.dm"
 #include "code\controllers\subsystems\processing\psi.dm"
 #include "code\controllers\subsystems\processing\temperature.dm"

--- a/code/__defines/subsystem-priority.dm
+++ b/code/__defines/subsystem-priority.dm
@@ -8,6 +8,7 @@
 // SS_TICKER
 #define SS_PRIORITY_TIMER          20
 #define SS_PRIORITY_ICON_UPDATE    20  // Queued icon updates. Mostly used by APCs and tables.
+#define SS_PRIORITY_OVERMAP        12  // Handles overmap processing. Keeps things smooth during highpop, ideally. // SIERRA
 
 // Normal
 #define SS_PRIORITY_TICKER         100 // Gameticker.

--- a/code/controllers/subsystems/processing/overmap.dm
+++ b/code/controllers/subsystems/processing/overmap.dm
@@ -1,0 +1,10 @@
+PROCESSING_SUBSYSTEM_DEF(overmap)
+
+/datum/controller/subsystem/processing/overmap
+	name = "Overmap"
+	priority = SS_PRIORITY_OVERMAP
+	flags = SS_TICKER|SS_NO_INIT
+	wait = 7
+
+/datum/controller/subsystem/processing/overmap/New()
+	NEW_SS_GLOBAL(SSovermap)

--- a/code/modules/overmap/ships/ship.dm
+++ b/code/modules/overmap/ships/ship.dm
@@ -48,11 +48,11 @@ var/global/const/OVERMAP_SPEED_CONSTANT = (1 SECOND)
 	min_speed = round(min_speed, SHIP_MOVE_RESOLUTION)
 	max_speed = round(max_speed, SHIP_MOVE_RESOLUTION)
 	SSshuttle.ships += src
-	START_PROCESSING(SSobj, src)
+	START_PROCESSING(SSovermap, src)
 	base_sensor_visibility = round((vessel_mass/SENSOR_COEFFICENT),1)
 
 /obj/effect/overmap/visitable/ship/Destroy()
-	STOP_PROCESSING(SSobj, src)
+	STOP_PROCESSING(SSovermap, src)
 	SSshuttle.ships -= src
 	if(LAZYLEN(consoles))
 		for(var/obj/machinery/computer/ship/machine in consoles)


### PR DESCRIPTION
Ещё воруем разные штуки с Авроры: Перекидываем работу овермапы на отдельную подсистему, что позволяет снизить время ожидания обработки SSObj и уменьшить лаги. 

<details>
<summary>Чейнджлог</summary>

```yml
🆑
experiment: Овермапа теперь обрабатывается отдельной подсистемой
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
