### PR TITLE
Bugfix неудаляемые консоли управления кораблём и сенсоров

### DIFF
--- a/code/modules/overmap/ships/computers/ship.dm
+++ b/code/modules/overmap/ships/computers/ship.dm
@@ -109,10 +109,11 @@ somewhere on that shuttle. Subtypes of these can be then used to perform ship ov
 		return 0
 
 /obj/machinery/computer/ship/Destroy()
-	//[SIERRA]
+	// linked.consoles -= src // BAY
+	// [SIERRA]
 	if(linked)
 		linked.consoles -= src
-	//[/SIERRA]
+	// [/SIERRA]
 	. = ..()
 
 /obj/machinery/computer/ship/sensors/Destroy()

--- a/code/modules/overmap/ships/computers/ship.dm
+++ b/code/modules/overmap/ships/computers/ship.dm
@@ -109,7 +109,10 @@ somewhere on that shuttle. Subtypes of these can be then used to perform ship ov
 		return 0
 
 /obj/machinery/computer/ship/Destroy()
-	linked.consoles -= src
+	//[SIERRA]
+	if(linked)
+		linked.consoles -= src
+	//[/SIERRA]
 	. = ..()
 
 /obj/machinery/computer/ship/sensors/Destroy()


### PR DESCRIPTION
Добавлена единственная проверка и теперь консоли сенсоров, управления кораблями возможно удалить и рантайма не появляется.

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Компьютерные консоли теперь удаляются
/🆑
```

</details>


- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
