### PR TITLE
Fix: Bartender spawn positions

### DIFF
--- a/maps/sierra/job/jobs_service.dm
+++ b/maps/sierra/job/jobs_service.dm
@@ -70,6 +70,8 @@
 
 /datum/job/bartender
 	title = "Bartender"
+	total_positions = 1
+	spawn_positions = 1
 	department = "Обслуживания"
 	department_flag = SRV
 	supervisors = "Главе Персонала"


### PR DESCRIPTION
Фиксит количество позиций спавна бармена с 0 до 1

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: За бармена теперь можно заспавниться
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
