### PR TITLE
fix: guest pass terminal ui template

### DIFF
--- a/nano/templates/guestpass.tmpl
+++ b/nano/templates/guestpass.tmpl
@@ -4,7 +4,7 @@
 
 	{{for data.internal_log}}
 		<div class="item">
-			{{value}}
+			{{:value}}
 		</div>
 	{{/for}}
 


### PR DESCRIPTION
Исправляет ошибку юи-темплейта guest pass терминала.

Fixes #241 (в этот раз точно)

Работает как должно:

![nowitworkslikeforsure](https://user-images.githubusercontent.com/79848183/232520416-68f5cca6-24cf-498f-879d-842b35fc91e6.png)
(кстати, есть дм-сайд проблемы: номера все одинаковые и запятая дублируется)

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Починил guest pass terminal
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
<!-- - [x] Я ебал рот вашего пулл реквест темплейта. -->