### PR TITLE
Tweak middleclick to make user point at atom

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -76,11 +76,6 @@
 	else if (modifiers["ctrl"] && modifiers["alt"])
 		if (CtrlAltClickOn(A))
 			return TRUE
-	// [SIERRA-ADD] - SSINPUT
-	else if(modifiers["middle"] && modifiers["alt"])
-		if (AltMiddleClickOn(A))
-			return TRUE
-	// [/SIERRA-ADD]
 	else if (modifiers["shift"] && modifiers["alt"])
 		if (AltShiftClickOn(A))
 			return TRUE
@@ -260,17 +255,15 @@
 /mob/proc/MiddleClickOn(atom/A)
 	if (A.MiddleClick(src))
 		return TRUE
-	swap_hand()
+	// [SIERRA-EDIT] - SSINPUT
+	// swap_hand() // SIERRA-EDIT - ORIGINAL
+	pointed(A)
+	// [/SIERRA-EDIT]
 	return TRUE
 
 /atom/proc/MiddleClick(mob/M as mob)
 	return FALSE
 
-// [SIERRA-ADD] - SSINPUT
-/mob/proc/AltMiddleClickOn(atom/A)
-	pointed(A)
-	return TRUE
-// [/SIERRA-ADD]
 
 /**
  * Called when the mob shift+clicks on an atom. By default, this calls the targeted atom's `ShiftClick()` proc.

--- a/mods/ssinput/README.md
+++ b/mods/ssinput/README.md
@@ -29,7 +29,7 @@ ID мода: SSINPUT
 
 - `code/__defines/subsystem-priority.dm`: `#define SS_PRIORITY_INPUT`
 - `code/__defines/subsystems.dm`: `#define SS_INIT_INPUT`
-- `code/_onclick/click.dm`: `/mob/proc/ClickOn()`, `/mob/proc/AltMiddleClickOn()`
+- `code/_onclick/click.dm`: `/mob/proc/MiddleClickOn()`
 - `code/game/verbs/ooc.dm`: `/client/verb/ooc()`, `/client/verb/looc()`
 - `code/modules/admin/callproc/callproc.dm`: `/client/Click()`
 - `code/modules/client/client_procs.dm`: `/client/New()`


### PR DESCRIPTION


<!-- ЗДЕСЬ нужно **расписать изменения** которые попадут в **чейнджлог**, формат - `prefix: краткое описание` -->
### Чейнджлог
```yml
🆑SuhEugene
tweak: СКМ теперь не требует нажатия Alt чтобы указывать на что-либо.
/🆑
```

<!--
  Честно заполняем галочки. Чем больше галочек, тем быстрее проверять Pull Request, соответственно он быстрее будет принят.
  Чтобы отметить - ставим `x` (икс) внутри квадратных скобочек вот так: `- [x] ...`.
  Галочки можно доставлять позже по мере окончания работы над PR'ом.
-->

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
