### PR TITLE
Фикс радиуса музыкального плеера

### DIFF
--- a/mods/music_player/code/music_player.dm
+++ b/mods/music_player/code/music_player.dm
@@ -474,7 +474,7 @@ GLOBAL_LIST_INIT(switch_small_sound, list(
 		sound_token.Unpause()
 	else
 		QDEL_NULL(sound_token)
-		sound_token = GLOB.sound_player.PlayLoopingSound(src, sound_id, tape.track.source, volume = volume, frequency = frequency, range = 7, falloff = 4, prefer_mute = TRUE)
+		sound_token = GLOB.sound_player.PlayLoopingSound(src, sound_id, tape.track.source, volume = volume, frequency = frequency, range = 9, falloff = 2, prefer_mute = TRUE)
 
 	mode = PLAYER_STATE_PLAY
 	START_PROCESSING(SSobj, src)

--- a/mods/music_player/code/subtypes_player.dm
+++ b/mods/music_player/code/subtypes_player.dm
@@ -72,3 +72,6 @@
 	name = "typ3n4m3-cl4ss: CRUSH/ZER0"
 	icon_state = "console"
 	tape = /obj/item/music_tape/custom
+	max_volume = 100
+	break_chance = 0
+	power_usage = 1


### PR DESCRIPTION
<!-- ЗДЕСЬ должно быть **подробное описание** того, что происходит в PR и зачем это нужно. PR не должен содержать изменений, о которых здесь ничего не сказано. -->
Изменение радиуса проигрывания плеера на 2 тайла и его затихание более реалистично. 

close #306 
close #665 
close #939 

### Чейнджлог
```yml
🆑 CuddleAndTea
tweak: Изменил расстояние проигрывания кастомных плееров (+2 тайла)
/🆑
```

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
