### PR TITLE
Robotics repairing chances redone

### DIFF
--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -20,6 +20,7 @@
 
 /singleton/surgery_step/robotics/success_chance(mob/living/user, mob/living/carbon/human/target, obj/item/tool)
 	. = ..()
+/* SIERRA REMOVE
 	if(!user.skill_check(SKILL_DEVICES, SKILL_TRAINED))
 		. -= 30
 	if(!user.skill_check(SKILL_DEVICES, SKILL_EXPERIENCED))
@@ -28,7 +29,15 @@
 		. += 35
 	if(user.skill_check(SKILL_DEVICES, SKILL_MASTER))
 		. += 30
-
+*/
+	if(!user.skill_check(SKILL_DEVICES, SKILL_BASIC))
+		. -= 20
+	if(!user.skill_check(SKILL_DEVICES, SKILL_TRAINED))
+		. -= 20
+	if(user.skill_check(SKILL_DEVICES, SKILL_EXPERIENCED))
+		. += 20
+	if(user.skill_check(SKILL_DEVICES, SKILL_MASTER))
+		. += 30
 //////////////////////////////////////////////////////////////////
 //	 unscrew robotic limb hatch surgery step
 //////////////////////////////////////////////////////////////////
@@ -186,9 +195,9 @@
 /singleton/surgery_step/robotics/repair_brute
 	name = "Repair damage to prosthetic"
 	allowed_tools = list(
-		/obj/item/weldingtool = 35,
-		/obj/item/weldingtool/electric = 50,
-		/obj/item/gun/energy/plasmacutter = 25,
+		/obj/item/weldingtool = 45,
+		/obj/item/weldingtool/electric = 60,
+		/obj/item/gun/energy/plasmacutter = 30,
 		/obj/item/psychic_power/psiblade/master = 100
 	)
 
@@ -197,13 +206,15 @@
 
 /singleton/surgery_step/robotics/repair_brute/success_chance(mob/living/user, mob/living/carbon/human/target, obj/item/tool)
 	. = ..()
-	if(user.skill_check(SKILL_CONSTRUCTION, SKILL_BASIC))
-		. += 5
+	if(!user.skill_check(SKILL_CONSTRUCTION, SKILL_BASIC))
+		. -= 15
 	if(user.skill_check(SKILL_CONSTRUCTION, SKILL_TRAINED))
-		. += 10
+		. += 15
+
+/* SIERRA REMOVE
 	if(!user.skill_check(SKILL_DEVICES, SKILL_EXPERIENCED))
 		. -= 10
-
+*/
 /singleton/surgery_step/robotics/repair_brute/pre_surgery_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	if(affected)
@@ -264,8 +275,10 @@
 		. += 10
 	if(user.skill_check(SKILL_CONSTRUCTION, SKILL_TRAINED))
 		. += 10
+/* SIERRA REMOVE
 	if(!user.skill_check(SKILL_DEVICES, SKILL_EXPERIENCED))
 		. -= 15
+*/
 
 /singleton/surgery_step/robotics/repair_brittle/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = ..()
@@ -305,13 +318,14 @@
 /singleton/surgery_step/robotics/repair_burn/success_chance(mob/living/user, mob/living/carbon/human/target, obj/item/tool)
 	. = ..()
 
-	if(user.skill_check(SKILL_ELECTRICAL, SKILL_BASIC))
-		. += 5
+	if(!user.skill_check(SKILL_ELECTRICAL, SKILL_BASIC))
+		. -= 15
 	if(user.skill_check(SKILL_ELECTRICAL, SKILL_TRAINED))
-		. += 10
+		. += 15
+/* SIERRA REMOVE
 	if(!user.skill_check(SKILL_DEVICES, SKILL_EXPERIENCED))
 		. -= 10
-
+*/
 /singleton/surgery_step/robotics/repair_burn/pre_surgery_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	if(affected)
@@ -698,6 +712,14 @@
 	)
 	min_duration = 50
 	max_duration = 60
+
+/singleton/surgery_step/robotics/robone/weld/success_chance(mob/living/user, mob/living/carbon/human/target, obj/item/tool)
+	. = ..()
+
+	if(user.skill_check(SKILL_CONSTRUCTION, SKILL_TRAINED))
+		. += 10
+	if(user.skill_check(SKILL_ELECTRICAL, SKILL_TRAINED))
+		. += 10
 
 /singleton/surgery_step/robotics/robone/weld/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)


### PR DESCRIPTION
<!-- ЗДЕСЬ должно быть **подробное описание** того, что происходит в PR и зачем это нужно. PR не должен содержать изменений, о которых здесь ничего не сказано. -->
Убрал лишние проверки на SKILL_DEVICES, SKILL_EXPERIENCED, который стакались друг на дружку и давали крутой минус к проверке. И поменял шансы, в сторону чуть большего их облегчения. 

<!-- ЗДЕСЬ нужно **привязать ишью**, которые относятся к PR'у в формате `close #1234` или `fixes #1234` - тогда они автоматически закроются вместе с PR. Можно написать `Затрагивает #1234, но не фиксит его`, если вы просто хотите упоминуть ишью, но не закрывать его. -->
close #0

<!-- ЗДЕСЬ нужно **расписать изменения** которые попадут в **чейнджлог**, формат - `prefix: краткое описание` -->
### Чейнджлог
```yml
🆑Lexanx
tweak: Шансы ремонта протезов изменены
/🆑
```

<!--
  Честно заполняем галочки. Чем больше галочек, тем быстрее проверять Pull Request, соответственно он быстрее будет принят.
  Чтобы отметить - ставим `x` (икс) внутри квадратных скобочек вот так: `- [x] ...`.
  Галочки можно доставлять позже по мере окончания работы над PR'ом.
-->

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
