### PR TITLE
MakeBottlesShatter

### DIFF
--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -90,9 +90,13 @@
 /obj/item/reagent_containers/glass/throw_impact(atom/hit_atom)
 	if (QDELETED(src))
 		return
-	if (!LAZYISIN(matter, MATERIAL_GLASS))
+	if (!LAZYISIN(matter, MATERIAL_GLASS) & length(reagents.reagent_list) > 0) // Не стеклянные предметы просто проливают содержимое на пол/моба, если содержимое есть
+//		if (length(reagents.reagent_list) > 0)
+		visible_message(
+			SPAN_DANGER("\The [src] bounces and spills all its contents!")
+		)
+		reagents.splash(hit_atom, reagents.total_volume)
 		return
-
 	if (prob(80))
 		if (length(reagents.reagent_list) > 0)
 			visible_message(
@@ -109,7 +113,7 @@
 		new /obj/item/material/shard(src.loc)
 		qdel(src)
 	else
-		if (length(reagents.reagent_list) > 0)
+		if (length(reagents.reagent_list) > 0 && is_open_container())
 			visible_message(
 				SPAN_DANGER("\The [src] bounces and spills all its contents!"),
 				SPAN_WARNING("You hear the sound of glass hitting something.")

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -113,7 +113,7 @@
 		new /obj/item/material/shard(src.loc)
 		qdel(src)
 	else
-		if (length(reagents.reagent_list) > 0 && is_open_container())
+		if ((length(reagents.reagent_list) > 0) && (is_open_container() | isnull(is_open_container())))
 			visible_message(
 				SPAN_DANGER("\The [src] bounces and spills all its contents!"),
 				SPAN_WARNING("You hear the sound of glass hitting something.")

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -90,7 +90,7 @@
 /obj/item/reagent_containers/glass/throw_impact(atom/hit_atom)
 	if (QDELETED(src))
 		return
-	if (!LAZYISIN(matter, MATERIAL_GLASS) & length(reagents.reagent_list) > 0) // Не стеклянные предметы просто проливают содержимое на пол/моба, если содержимое есть
+	if (!LAZYISIN(matter, MATERIAL_GLASS) && (length(reagents.reagent_list) > 0)) // Не стеклянные предметы просто проливают содержимое на пол/моба, если содержимое есть
 //		if (length(reagents.reagent_list) > 0)
 		visible_message(
 			SPAN_DANGER("\The [src] bounces and spills all its contents!")
@@ -113,7 +113,7 @@
 		new /obj/item/material/shard(src.loc)
 		qdel(src)
 	else
-		if ((length(reagents.reagent_list) > 0) && (is_open_container() | isnull(is_open_container())))
+		if ((length(reagents.reagent_list) > 0) && (is_open_container() || isnull(is_open_container())))
 			visible_message(
 				SPAN_DANGER("\The [src] bounces and spills all its contents!"),
 				SPAN_WARNING("You hear the sound of glass hitting something.")

--- a/code/modules/reagents/reagent_containers/glass/bottle.dm
+++ b/code/modules/reagents/reagent_containers/glass/bottle.dm
@@ -11,7 +11,7 @@
 	w_class = ITEM_SIZE_SMALL
 	obj_flags = 0
 	volume = 60
-
+	matter = list(MATERIAL_GLASS = 500)
 
 /obj/item/reagent_containers/glass/bottle/on_reagent_change()
 	update_icon()


### PR DESCRIPTION
Изменена проверка LAZYISIN при броске - если дочерний от reagent_containers/glass предмет не из стекла но содержит что-то внутри то он теперь не просто кинется, но и прольет содержимое. Добавлена проверка по флагу is_open_container на случай, если стекляшка при броске закрыта, не разбилась, но имеет содержимое - тогда она не прольется. Бутыльки стоят по 500 стекла.

Задевает #2181, но коктейли Молотова все еще работают непонятно как (как правило они не работают - он разбивается, но топливо не горит). Пусть будет открытым, наверное

### Чейнджлог
```yml
🆑Quadro21
tweak: Бутыльки теперь стоят 500 стекла. Добавлена проверка, открыт ли бутылек или бикер. Если закрытые бутыльки и бикеры с содержимым при броске не разобьются то и ничего не прольют. Ведра при броске теперь проливают содержимое (но на стекло не разбиваются ): )
/🆑
```

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
