### PR TITLE
bugfix: /mob/login no longer executes parent proc

### DIFF
--- a/code/_onclick/hud/ability_screen_objects.dm
+++ b/code/_onclick/hud/ability_screen_objects.dm
@@ -155,11 +155,6 @@
 			return S
 	return null
 
-/mob/Login()
-	..()
-	if(ability_master)
-		ability_master.update_abilities(1, src)
-		ability_master.toggle_open(1)
 
 /mob/Initialize()
 	. = ..()

--- a/code/_onclick/hud/skybox.dm
+++ b/code/_onclick/hud/skybox.dm
@@ -55,9 +55,6 @@
 	sleep(1)
 	update_skybox(rebuild)
 
-/mob/Login()
-	..()
-	client.deferred_skybox_update(TRUE)
 
 /mob/Move()
 	var/old_z = get_z(src)

--- a/code/datums/observation/logged_in.dm
+++ b/code/datums/observation/logged_in.dm
@@ -11,11 +11,3 @@ GLOBAL_DATUM_INIT(logged_in_event, /singleton/observ/logged_in, new)
 /singleton/observ/logged_in
 	name = "Logged In"
 	expected_type = /mob
-
-/*****************
-* Login Handling *
-*****************/
-
-/mob/Login()
-	..()
-	GLOB.logged_in_event.raise_event(src)

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -60,7 +60,19 @@
 	var/logout_time = null
 
 /mob/Login()
-	..()
+
+
+	// DO NOT CALL PARENT HERE
+	// BYOND's internal implementation of login does two things
+	// 1: Set statobj to the mob being logged into (We got this covered)
+	// 2: And I quote "If the mob has no location, place it near (1,1,1) if possible"
+	// See, near is doing an agressive amount of legwork there
+	// What it actually does is takes the area that (1,1,1) is in, and loops through all those turfs
+	// If you successfully move into one, it stops
+	// Because we want Move() to mean standard movements rather then just what byond treats it as (ALL moves)
+	// We don't allow moves from nullspace -> somewhere. This means the loop has to iterate all the turfs in (1,1,1)'s area
+	// For us, (1,1,1) is a space tile. This means roughly 200,000! calls to Move()
+	// You do not want this
 
 	// Add to player list if missing
 	if (!GLOB.player_list.Find(src))
@@ -110,6 +122,22 @@
 	if (SScharacter_setup.initialized && SSchat.initialized && !isnull(client.chatOutput))
 		if(client.get_preference_value(/datum/client_preference/goonchat) == GLOB.PREF_YES)
 			client.chatOutput.start()
+
+	GLOB.logged_in_event.raise_event(src)
+
+	if(mind)
+		if(!mind.learned_spells)
+			mind.learned_spells = list()
+		if(ability_master && ability_master.spell_objects)
+			for(var/obj/screen/ability/spell/screen in ability_master.spell_objects)
+				var/spell/S = screen.spell
+				mind.learned_spells |= S
+
+	client.deferred_skybox_update(TRUE)
+
+	if(ability_master)
+		ability_master.update_abilities(1, src)
+		ability_master.toggle_open(1)
 
 	//set macro to normal incase it was overriden (like cyborg currently does)
 	// [SIERRA-REMOVE] - SSINPUT

--- a/code/modules/spells/spells.dm
+++ b/code/modules/spells/spells.dm
@@ -16,16 +16,6 @@
 				if(Sp_HOLDVAR)
 					statpanel(S.panel,"[S.holder_var_type] [S.holder_var_amount]",S.connected_button)
 
-//A fix for when a spell is created before a mob is created
-/mob/Login()
-	. = ..()
-	if(mind)
-		if(!mind.learned_spells)
-			mind.learned_spells = list()
-		if(ability_master && ability_master.spell_objects)
-			for(var/obj/screen/ability/spell/screen in ability_master.spell_objects)
-				var/spell/S = screen.spell
-				mind.learned_spells |= S
 
 /proc/restore_spells(mob/H)
 	if(H.mind && H.mind.learned_spells)


### PR DESCRIPTION
<!-- ЗДЕСЬ должно быть **подробное описание** того, что происходит в PR и зачем это нужно. PR не должен содержать изменений, о которых здесь ничего не сказано. -->
PR убирает вызов родительского метода /mob/login для предотвращения скачков по куче турфов и, как следствие, лагов.
<!-- ЗДЕСЬ нужно **расписать изменения** которые попадут в **чейнджлог**, формат - `prefix: краткое описание` -->
### Чейнджлог
```yml
🆑Vladisvell
bugfix: Устранены некоторые лаги, связанные с заходом игрока в игру.
/🆑
```

<!--
  Честно заполняем галочки. Чем больше галочек, тем быстрее проверять Pull Request, соответственно он быстрее будет принят.
  Чтобы отметить - ставим `x` (икс) внутри квадратных скобочек вот так: `- [x] ...`.
  Галочки можно доставлять позже по мере окончания работы над PR'ом.
-->

- [ ] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [ ] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [ ] Я запускал сервер со своими изменениями локально и все протестировал.
