### PR TITLE
Новый интерфейс для мод-меню

### DIFF
--- a/code/controllers/subsystems/initialization/modpacks.dm
+++ b/code/controllers/subsystems/initialization/modpacks.dm
@@ -9,32 +9,35 @@ SUBSYSTEM_DEF(modpacks)
 
 	// Pre-init and register all compiled modpacks.
 	for(var/package in all_modpacks)
-		var/singleton/modpack/modlist = all_modpacks[package]
-		var/fail_msg = modlist.pre_initialize()
-		if(QDELETED(modlist))
+		var/singleton/modpack/manifest = all_modpacks[package]
+		var/fail_msg = manifest.pre_initialize()
+		if(QDELETED(manifest))
 			crash_with("Modpack of type [package] is null or queued for deletion.")
 			continue
 		if(fail_msg)
-			crash_with("Modpack [modlist.name] failed to pre-initialize: [fail_msg].")
+			crash_with("Modpack [manifest.name] failed to pre-initialize: [fail_msg].")
 			continue
-		if(loaded_modpacks[modlist.name])
-			crash_with("Attempted to register duplicate modpack name [modlist.name].")
+		if(loaded_modpacks[manifest.name])
+			crash_with("Attempted to register duplicate modpack name [manifest.name].")
 			continue
-		loaded_modpacks[modlist.name] = modlist
+		loaded_modpacks[manifest.name] = manifest
 
 	// Handle init and post-init (two stages in case a modpack needs to implement behavior based on the presence of other packs).
 	for(var/package in all_modpacks)
-		var/singleton/modpack/modlist = all_modpacks[package]
-		var/fail_msg = modlist.initialize()
+		var/singleton/modpack/manifest = all_modpacks[package]
+		var/fail_msg = manifest.initialize()
 		if(fail_msg)
-			crash_with("Modpack [(istype(modlist) && modlist.name) || "Unknown"] failed to initialize: [fail_msg]")
+			crash_with("Modpack [(istype(manifest) && manifest.name) || "Unknown"] failed to initialize: [fail_msg]")
 	for(var/package in all_modpacks)
-		var/singleton/modpack/modlist = all_modpacks[package]
-		var/fail_msg = modlist.post_initialize()
+		var/singleton/modpack/manifest = all_modpacks[package]
+		var/fail_msg = manifest.post_initialize()
 		if(fail_msg)
-			crash_with("Modpack [(istype(modlist) && modlist.name) || "Unknown"] failed to post-initialize: [fail_msg]")
+			crash_with("Modpack [(istype(manifest) && manifest.name) || "Unknown"] failed to post-initialize: [fail_msg]")
 
 	. = ..()
+
+/datum/controller/subsystem/modpacks/UpdateStat()
+	..("Modpacks: [length(loaded_modpacks)]")
 
 /datum/controller/subsystem/modpacks/UpdateStat()
 	..("Modpacks: [length(loaded_modpacks)]")

--- a/code/controllers/subsystems/initialization/modpacks.dm
+++ b/code/controllers/subsystems/initialization/modpacks.dm
@@ -9,30 +9,30 @@ SUBSYSTEM_DEF(modpacks)
 
 	// Pre-init and register all compiled modpacks.
 	for(var/package in all_modpacks)
-		var/singleton/modpack/manifest = all_modpacks[package]
-		var/fail_msg = manifest.pre_initialize()
-		if(QDELETED(manifest))
+		var/singleton/modpack/modlist = all_modpacks[package]
+		var/fail_msg = modlist.pre_initialize()
+		if(QDELETED(modlist))
 			crash_with("Modpack of type [package] is null or queued for deletion.")
 			continue
 		if(fail_msg)
-			crash_with("Modpack [manifest.name] failed to pre-initialize: [fail_msg].")
+			crash_with("Modpack [modlist.name] failed to pre-initialize: [fail_msg].")
 			continue
-		if(loaded_modpacks[manifest.name])
-			crash_with("Attempted to register duplicate modpack name [manifest.name].")
+		if(loaded_modpacks[modlist.name])
+			crash_with("Attempted to register duplicate modpack name [modlist.name].")
 			continue
-		loaded_modpacks[manifest.name] = manifest
+		loaded_modpacks[modlist.name] = modlist
 
 	// Handle init and post-init (two stages in case a modpack needs to implement behavior based on the presence of other packs).
 	for(var/package in all_modpacks)
-		var/singleton/modpack/manifest = all_modpacks[package]
-		var/fail_msg = manifest.initialize()
+		var/singleton/modpack/modlist = all_modpacks[package]
+		var/fail_msg = modlist.initialize()
 		if(fail_msg)
-			crash_with("Modpack [(istype(manifest) && manifest.name) || "Unknown"] failed to initialize: [fail_msg]")
+			crash_with("Modpack [(istype(modlist) && modlist.name) || "Unknown"] failed to initialize: [fail_msg]")
 	for(var/package in all_modpacks)
-		var/singleton/modpack/manifest = all_modpacks[package]
-		var/fail_msg = manifest.post_initialize()
+		var/singleton/modpack/modlist = all_modpacks[package]
+		var/fail_msg = modlist.post_initialize()
 		if(fail_msg)
-			crash_with("Modpack [(istype(manifest) && manifest.name) || "Unknown"] failed to post-initialize: [fail_msg]")
+			crash_with("Modpack [(istype(modlist) && modlist.name) || "Unknown"] failed to post-initialize: [fail_msg]")
 
 	. = ..()
 
@@ -47,24 +47,35 @@ SUBSYSTEM_DEF(modpacks)
 		return
 
 	if(length(SSmodpacks.loaded_modpacks))
-		. = "<hr><br><center><b><font size = 3>Список модификаций</font></b></center><br><hr><br>"
-		for(var/modpack in SSmodpacks.loaded_modpacks)
-			var/singleton/modpack/M = SSmodpacks.loaded_modpacks[modpack]
-
-			if(M.name)
-				. += "<div class = 'statusDisplay'>"
-				. += "<center><b>[M.name]</b></center>"
-
-				if(M.desc || M.author)
-					. += "<br>"
-					if(M.desc)
-						. += "<br>Описание: [M.desc]"
-					if(M.author)
-						. += "<br><i>Автор: [M.author]</i>"
-				. += "</div><br>"
-
-		var/datum/browser/popup = new(mob, "modpacks_list", "Список Модификаций", 480, 580)
-		popup.set_content(.)
-		popup.open()
+		var/datum/nano_module/modlist/modlist_panel = locate("modlist_[usr.ckey]")
+		if(!modlist_panel)
+			modlist_panel = new /datum/nano_module/modlist(usr)
+			modlist_panel.tag = "modlist_[usr.ckey]"
+		modlist_panel.ui_interact(usr)
 	else
 		to_chat(src, SPAN_WARNING("Этот сервер не использует какие-либо модификации."))
+
+/datum/nano_module/modlist
+
+/datum/nano_module/modlist/CanUseTopic(mob/user, datum/topic_state/state = GLOB.xeno_state)
+	. = ..()
+
+/datum/nano_module/modlist/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1, datum/topic_state/state = GLOB.xeno_state)
+	var/data[0]
+	var/list/mods = list()
+	for(var/modpack in SSmodpacks.loaded_modpacks)
+		var/singleton/modpack/mod = SSmodpacks.loaded_modpacks[modpack]
+		if(mod.name)
+			mods[LIST_PRE_INC(mods)] = list("name" = mod.name, "description" = mod.desc ? mod.desc : "Нет описания", "author" = mod.author ? mod.author : "Нет автора")
+
+	data["mods"] = mods
+	ui = SSnano.try_update_ui(user, src, ui_key, ui, data, force_open)
+	if(!ui)
+		ui = new(user, src, ui_key, "mods-modlist.tmpl", "Список модификаций", 350, 500, state = state)
+		ui.set_initial_data(data)
+		ui.open()
+		ui.set_auto_update(1)
+
+/datum/nano_module/modlist/Topic(href, href_list, state)
+	if(..())
+		return TRUE

--- a/code/controllers/subsystems/initialization/modpacks.dm
+++ b/code/controllers/subsystems/initialization/modpacks.dm
@@ -39,9 +39,6 @@ SUBSYSTEM_DEF(modpacks)
 /datum/controller/subsystem/modpacks/UpdateStat()
 	..("Modpacks: [length(loaded_modpacks)]")
 
-/datum/controller/subsystem/modpacks/UpdateStat()
-	..("Modpacks: [length(loaded_modpacks)]")
-
 /client/verb/modpacks_list()
 	set name = "Modpacks List"
 	set category = "OOC"

--- a/nano/css/modern.css
+++ b/nano/css/modern.css
@@ -112,17 +112,19 @@ a.linkDanger:hover {
 .labelList-item {
     display: flex;
     justify-content: space-between;
-    align-items: center;
+    align-items: top;
     margin-bottom: 2px;
 }
 
 .labelList-item-label {
     color: #7e90a7;
+    margin-right: 10px;
 }
 
 .labelList-item-content {
     display: flex;
-    align-items: center;
+    align-items: top;
+    justify-content: left;
 }
 
 .table-row {

--- a/nano/templates/mods/modlist.tmpl
+++ b/nano/templates/mods/modlist.tmpl
@@ -1,0 +1,48 @@
+{{for data.mods}}
+    <div class="section">
+        <div class="section-title">
+            {{:value.name}}
+        </div>
+        <div class="section-content">
+            <div class="labelList">
+                <div class="labelList-item">
+                    <div class="labelList-item-label">
+                        Описание:
+                    </div>
+                    <div class="labelList-item-content">
+                        {{:value.description}}
+                    </div>
+                </div>
+                <div class="labelList-item">
+                    <div class="labelList-item-label">
+                        Автор:
+                    </div>
+                    <div class="labelList-item-content">
+                        {{:value.author}}
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+{{/for}}
+<!--
+<div class="section">
+	<div class="section-title">
+
+	</div>
+	<div class="section-content">
+
+	</div>
+</div>
+
+<div class="labelList">
+	<div class="labelList-item">
+		<div class="labelList-item-label">
+
+		</div>
+		<div class="labelList-item-content">
+
+		</div>
+	</div>
+</div>
+-->


### PR DESCRIPTION
PR добавляет новый интерфейс для мод-меню
![изображение](https://github.com/user-attachments/assets/fe9a6df2-69ee-4a72-9943-485e513af719)

### Чейнджлог
```yml
🆑FeudeyTF
rscadd: Добавил новый интерфейс для мод-меню
/🆑
```

<!--
  Честно заполняем галочки. Чем больше галочек, тем быстрее проверять Pull Request, соответственно он быстрее будет принят.
  Чтобы отметить - ставим `x` (икс) внутри квадратных скобочек вот так: `- [x] ...`.
  Галочки можно доставлять позже по мере окончания работы над PR'ом.
-->

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
