### PR TITLE
Фикс падения при отсутствии сознания/сне

### DIFF
--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -38,11 +38,7 @@
 
 	handle_actions()
 
-//[SIERRA-EDIT]
-	if(update_icon)	//forces a full overlay update
-		update_icon = FALSE
-		regenerate_icons()
-//[/SIERRA-EDIT]
+	UpdateLyingBuckledAndVerbStatus()
 
 	handle_regular_hud_updates()
 


### PR DESCRIPTION
<!-- ЗДЕСЬ должно быть **подробное описание** того, что происходит в PR и зачем это нужно. PR не должен содержать изменений, о которых здесь ничего не сказано. -->
#2615 и #2594. Убирает основную проблему, из-за которой персонаж не падает при потере сознания. (Верб sleep, стазис под, логаут)

Такое изменение было сделано для пиксельшифта еще на staging-sierra, но не смог отследить для чего потребовалось данное разделение. На локалке сам пиксельшифт проверил после своего изменения, разницы не нашел.
https://github.com/SierraBay/SierraBay12/blob/ac40ff26be0cb05df2ce2a869c2481827d7f019f/code/modules/mob/living/life.dm#L39-L45

Все еще может быть проблема, что персонаж не всегда падает при использовании верба Ghost, но проверял на оффах и там тоже самое может быть.

<!-- ЗДЕСЬ нужно **привязать ишью**, которые относятся к PR'у в формате `close #1234` или `fixes #1234` - тогда они автоматически закроются вместе с PR. Можно написать `Затрагивает #1234, но не фиксит его`, если вы просто хотите упоминуть ишью, но не закрывать его. -->
close #2615
close #2594

<!-- ЗДЕСЬ нужно **расписать изменения** которые попадут в **чейнджлог**, формат - `prefix: краткое описание` -->
### Чейнджлог
```yml
🆑Builder13
bugfix: Фикс отсутствия падения персонажа при потере сознания
/🆑
```

<!--
  Честно заполняем галочки. Чем больше галочек, тем быстрее проверять Pull Request, соответственно он быстрее будет принят.
  Чтобы отметить - ставим `x` (икс) внутри квадратных скобочек вот так: `- [x] ...`.
  Галочки можно доставлять позже по мере окончания работы над PR'ом.
-->

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
