### PR TITLE
Фикс карго поезда и отображения скрапа

### DIFF
--- a/packs/infinity/machinery/scrap_compactor/scrap.dm
+++ b/packs/infinity/machinery/scrap_compactor/scrap.dm
@@ -5,7 +5,7 @@
 	name = MATERIAL_SCRAP
 	stack_type = /obj/item/stack/material/scrap
 	icon_colour = "#999966"
-	sheet_icon_base = "sheet"
+	sheet_icon_base = "unrefined"
 	sheet_icon_reinf = "reinf-overlay"
 	wall_icon_base = "metal"
 	door_icon_base = "metal"
@@ -21,9 +21,11 @@
 	hardness = 30
 	hitsound = 'sound/weapons/smash.ogg'
 	sale_price = 1
+	sheet_has_plural_icon = FALSE
 
 /material/scrap/refined
 	name = MATERIAL_SCRAP_REFINED
+	sheet_icon_base = "refined"
 	stack_type = /obj/item/stack/material/refined_scrap
 	melting_point = 820
 	brute_armor = 4
@@ -36,11 +38,9 @@
 /obj/item/stack/material/scrap
 	name = MATERIAL_SCRAP
 	icon = 'packs/infinity/machinery/scrap_compactor/icons/refine.dmi'
-	icon_state = "refined"
 	default_type = MATERIAL_SCRAP
 
 /obj/item/stack/material/refined_scrap
 	name = MATERIAL_SCRAP_REFINED
 	icon = 'packs/infinity/machinery/scrap_compactor/icons/refine.dmi'
-	icon_state = "refined"
 	default_type = MATERIAL_SCRAP_REFINED

--- a/packs/sierra-tweaks/objects/vehicles/train.dm
+++ b/packs/sierra-tweaks/objects/vehicles/train.dm
@@ -24,7 +24,8 @@
 /obj/vehicle/train/Initialize()
 	. = ..()
 	for(var/obj/vehicle/train/T in orange(1, src))
-		latch(T)
+		if(!T.powered)
+			latch(T)
 
 /obj/vehicle/train/examine(mob/user)
 	. = ..()

--- a/packs/sierra-tweaks/objects/vehicles/vehicle.dm
+++ b/packs/sierra-tweaks/objects/vehicles/vehicle.dm
@@ -1,3 +1,12 @@
+/datum/movement_handler/mob/buckle_relay/DoMove(direction, mover)
+	..()
+	if(istype(mob.buckled, /obj/vehicle))
+		. = MOVEMENT_HANDLED
+		if(mob.is_confused() && prob(20)) //vehicles tend to keep moving in the same direction
+			direction = turn(direction, pick(90, -90))
+		mob.buckled.relaymove(mob, direction)
+		return
+
 //Dummy object for holding items in vehicles.
 //Prevents items from being interacted with.
 /datum/vehicle_dummy_load


### PR DESCRIPTION
<!-- ЗДЕСЬ должно быть **подробное описание** того, что происходит в PR и зачем это нужно. PR не должен содержать изменений, о которых здесь ничего не сказано. -->
Возвращает возможность для перемещения карго поезда.

Также убирает авто подсоединение двигателя к вагонеткам, так как он и так сейчас неправильно подключается и из-за этого не может перемещаться.

Фиксит https://github.com/SierraBay/SierraBay12/issues/2668. Спрайта нет только для множественных листов.

<!-- ЗДЕСЬ нужно **привязать ишью**, которые относятся к PR'у в формате `close #1234` или `fixes #1234` - тогда они автоматически закроются вместе с PR. Можно написать `Затрагивает #1234, но не фиксит его`, если вы просто хотите упоминуть ишью, но не закрывать его. -->
close #2668

<!-- ЗДЕСЬ нужно **расписать изменения** которые попадут в **чейнджлог**, формат - `prefix: краткое описание` -->
### Чейнджлог
```yml
🆑Builder13
bugfix: Возвращена возможность перемещения для карго поезда
bugfix: Исправлено отображение для скрапа и переработанного скрапа
/🆑
```

<!--
  Честно заполняем галочки. Чем больше галочек, тем быстрее проверять Pull Request, соответственно он быстрее будет принят.
  Чтобы отметить - ставим `x` (икс) внутри квадратных скобочек вот так: `- [x] ...`.
  Галочки можно доставлять позже по мере окончания работы над PR'ом.
-->

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
