### PR TITLE
Возврат старых шансов на дизарм

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -3371,6 +3371,7 @@
 #include "mods\_master_files\code\modules\overmap\panicbutton.dm"
 #include "mods\_master_files\code\modules\power\gravitygenerator.dm"
 #include "mods\_master_files\code\modules\projectiles\projectile\bullets.dm"
+#include "mods\_master_files\code\modules\species\species.dm"
 #include "mods\_master_files\code\modules\species\station\adherent.dm"
 #include "mods\_master_files\code\modules\species\station\machine.dm"
 #include "mods\_master_files\maps\mapsystem\maps.dm"

--- a/mods/_master_files/code/modules/species/species.dm
+++ b/mods/_master_files/code/modules/species/species.dm
@@ -1,0 +1,49 @@
+/datum/species/disarm_attackhand(mob/living/carbon/human/attacker, mob/living/carbon/human/target)
+	attacker.do_attack_animation(target)
+
+	if(target.w_uniform)
+		target.w_uniform.add_fingerprint(attacker)
+	var/obj/item/organ/external/affecting = target.get_organ(ran_zone(attacker.zone_sel.selecting))
+
+	var/list/holding = list(target.get_active_hand() = 60, target.get_inactive_hand() = 30)
+
+	var/skill_mod = 10 * attacker.get_skill_difference(SKILL_COMBAT, target)
+	var/state_mod = attacker.melee_accuracy_mods() - target.melee_accuracy_mods()
+	var/stim_mod = target.chem_effects[CE_STIMULANT]
+	var/push_threshold = 20
+	var/disarm_threshold = 50
+
+	if(target.a_intent == I_HELP)
+		state_mod -= 30
+	//Handle unintended consequences
+	for(var/obj/item/I in holding)
+		var/hurt_prob = max(holding[I] - 3*skill_mod, 0)
+		if(prob(hurt_prob) && I.on_disarm_attempt(target, attacker))
+			return
+
+	var/randn = rand(1, 100) - skill_mod + state_mod - stim_mod
+	if(!(check_no_slip(target)) && randn <= push_threshold)
+		var/armor_check = 100 * target.get_blocked_ratio(affecting, DAMAGE_BRUTE, damage = 20)
+		target.apply_effect(2, EFFECT_WEAKEN, armor_check)
+		playsound(target.loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
+		if(armor_check < 100)
+			target.visible_message(SPAN_DANGER("[attacker] has pushed [target]!"))
+		else
+			target.visible_message(SPAN_WARNING("[attacker] attempted to push [target]!"))
+		return
+
+	if(randn <= disarm_threshold)
+		//See about breaking grips or pulls
+		if(target.break_all_grabs(attacker))
+			playsound(target.loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
+			return
+
+		//Actually disarm them
+		for(var/obj/item/I in holding)
+			if(I && target.unEquip(I))
+				target.visible_message(SPAN_DANGER("[attacker] has disarmed [target]!"))
+				playsound(target.loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
+				return
+
+	playsound(target.loc, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
+	target.visible_message(SPAN_DANGER("[attacker] attempted to disarm \the [target]!"))


### PR DESCRIPTION
<!-- ЗДЕСЬ должно быть **подробное описание** того, что происходит в PR и зачем это нужно. PR не должен содержать изменений, о которых здесь ничего не сказано. -->
Возвращает старые шансы на дизарм (https://github.com/ss220-space/Baystation12/blob/14cec0af0f6dafd5555a6f530ab3113ce5dbac7c/code/modules/species/species.dm#L647C37-L693C2). Делает дизарм более зависимым от проставленного скилла. Максимальная разница скилла между мастером и untrained - 4. На текущий момент при дизарме мастера на untrained дает +4% к толчку и +8% на выбить оружие.

<!-- ЗДЕСЬ нужно **привязать ишью**, которые относятся к PR'у в формате `close #1234` или `fixes #1234` - тогда они автоматически закроются вместе с PR. Можно написать `Затрагивает #1234, но не фиксит его`, если вы просто хотите упоминуть ишью, но не закрывать его. -->
close #0

<!-- ЗДЕСЬ нужно **расписать изменения** которые попадут в **чейнджлог**, формат - `prefix: краткое описание` -->
### Чейнджлог
```yml
🆑Builder13
tweak: Возвращены старые шансы на дизарм. Стал более зависимым от проставленного скилла
/🆑
```

<!--
  Честно заполняем галочки. Чем больше галочек, тем быстрее проверять Pull Request, соответственно он быстрее будет принят.
  Чтобы отметить - ставим `x` (икс) внутри квадратных скобочек вот так: `- [x] ...`.
  Галочки можно доставлять позже по мере окончания работы над PR'ом.
-->

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
