### PR TITLE
Возврат вкладки size converter для интегральных плат

### DIFF
--- a/mods/integrated_circuits/README.md
+++ b/mods/integrated_circuits/README.md
@@ -2,6 +2,7 @@
 #### Список PRов:
 
 - https://github.com/SierraBay/SierraBay12/pull/2655
+- https://github.com/SierraBay/SierraBay12/pull/2681
 <!--
   Ссылки на PRы, связанные с модом:
   - Создание
@@ -70,6 +71,8 @@ ID мода: INTEGRATED_CIRCUITS
 ### Авторы:
 
 Builder13
+
+Size converter - https://github.com/ss220-space/Baystation12/pull/18 (Predeiter)
 <!--
   Здесь находится твой никнейм
   Если работал совместно - никнеймы тех, кто помогал.

--- a/mods/integrated_circuits/_integrated_circuits.dme
+++ b/mods/integrated_circuits/_integrated_circuits.dme
@@ -7,5 +7,6 @@
 #include "code/pai.dm"
 #include "code/input.dm"
 #include "code/manipulation.dm"
+#include "code/size_converter.dm"
 
 #endif

--- a/mods/integrated_circuits/code/size_converter.dm
+++ b/mods/integrated_circuits/code/size_converter.dm
@@ -1,0 +1,21 @@
+/obj/item/integrated_circuit/size_converter
+	category_text = "Size Converters"
+
+/obj/item/integrated_circuit/size_converter/bluespace_circuit_expander
+	name = "Bluespace circuit expander"
+	desc = "This circuit use bluspace tech to crate mini rift for storing more compenents in assemble."
+	icon_state = "template"
+	extended_desc = "Finaly useful way use bluspace"
+	size = -25
+	complexity = 25
+	spawn_flags = IC_SPAWN_RESEARCH
+
+/obj/item/integrated_circuit/size_converter/expansion_board
+	name = "Expansion board"
+	desc = "Expansion board with connectors for easy component installation"
+	icon_state = "template"
+	extended_desc = "Board with signed connectors for easy installation, if the component is not installed, you should push it harder."
+	size = 25
+	complexity = -25
+	spawn_flags = IC_SPAWN_RESEARCH
+	//need balancing this shit


### PR DESCRIPTION
<!-- ЗДЕСЬ должно быть **подробное описание** того, что происходит в PR и зачем это нужно. PR не должен содержать изменений, о которых здесь ничего не сказано. -->
Возвращает вкладку size converter и две платы к нему, у принтера интегральных плат. Для увеличения максимального количества вставляемых плат за счет сложности устройства или наоборот. (Оригинальный ПР: https://github.com/ss220-space/Baystation12/pull/18)

<!-- ЗДЕСЬ нужно **привязать ишью**, которые относятся к PR'у в формате `close #1234` или `fixes #1234` - тогда они автоматически закроются вместе с PR. Можно написать `Затрагивает #1234, но не фиксит его`, если вы просто хотите упоминуть ишью, но не закрывать его. -->
close #0

<!-- ЗДЕСЬ нужно **расписать изменения** которые попадут в **чейнджлог**, формат - `prefix: краткое описание` -->
### Чейнджлог
```yml
🆑Builder13
rscadd: Возвращена вкладка size converter для принтера интегральных плат
/🆑
```

<!--
  Честно заполняем галочки. Чем больше галочек, тем быстрее проверять Pull Request, соответственно он быстрее будет принят.
  Чтобы отметить - ставим `x` (икс) внутри квадратных скобочек вот так: `- [x] ...`.
  Галочки можно доставлять позже по мере окончания работы над PR'ом.
-->

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
