### PR TITLE
Remove lack of headgib fix

### DIFF
--- a/code/modules/projectiles/guns/launcher/money_cannon.dm
+++ b/code/modules/projectiles/guns/launcher/money_cannon.dm
@@ -57,8 +57,8 @@
 		release_force = 0
 		return
 
-	// Must launch at least 100 thaler to incur damage.
-	release_force = dispensing / 100
+	// Must launch at least 100 thaler to incur damage. Max of 15k to prevent infinite damage.
+	release_force = min(dispensing / 100, 150)
 
 /obj/item/gun/launcher/money/proc/unload_receptacle(mob/user)
 	if(receptacle_value < 1)


### PR DESCRIPTION
Made money cannon do a max of 30 damage instead of infinite

### Чейнджлог
```yml
🆑awkardlyconfusedneuralnetwork
bugfix: fixed this instant headgib exploit that dumb as hell
/🆑
```

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [ ] Я запускал сервер со своими изменениями локально и все протестировал.
