### PR TITLE
Переломы Адхерантов.

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -3333,6 +3333,7 @@
 #include "mods\_master_files\code\game\world.dm"
 #include "mods\_master_files\code\game\gamemodes\ert.dm"
 #include "mods\_master_files\code\game\objects\effects\decals\contraband.dm"
+#include "mods\_master_files\code\game\objects\structures\mineral_bath.dm"
 #include "mods\_master_files\code\game\objects\structures\signs.dm"
 #include "mods\_master_files\code\game\objects\structures\crates_lockers\closets\_closet_appearance_definitions.dm"
 #include "mods\_master_files\code\modules\client\asset_cache.dm"

--- a/mods/_master_files/code/game/objects/structures/mineral_bath.dm
+++ b/mods/_master_files/code/game/objects/structures/mineral_bath.dm
@@ -1,0 +1,17 @@
+/obj/structure/adherent_bath/Process()
+	..()
+
+	if(ishuman(occupant))
+		var/mob/living/carbon/human/H = occupant
+
+		if(H.species.name == SPECIES_ADHERENT && prob(1))
+			for(var/obj/item/organ/external/E in H.organs)
+				if(E.status & ORGAN_BROKEN)
+					E.mend_fracture()
+					to_chat(H, SPAN_NOTICE("The mineral-rich bath mends internal structure of your [E.name]."))
+					break
+
+				if(istype(E, /obj/item/organ/external/head) && E.status & ORGAN_DISFIGURED)
+					E.status &= ~ORGAN_DISFIGURED
+					to_chat(H, SPAN_NOTICE("The mineral-rich bath mends your [E.name]."))
+					break


### PR DESCRIPTION
<!-- ЗДЕСЬ должно быть **подробное описание** того, что происходит в PR и зачем это нужно. PR не должен содержать изменений, о которых здесь ничего не сказано. -->
Делает возможным устранение переломов для Адхерантов через минеральные ванны. Заодно восстанавливает также 'лицо' при деформации.

На текущий момент, Адхеранты не могут лечить собственные переломы каким-либо способом. Операции из https://github.com/SierraBay/SierraBay12/blob/a9bd3d47ac3abb4ccc17dcfa394f0f0b3b00463d/code/modules/surgery/crystal.dm#L4 на них не работают, так как органы у них роботизированы. Единственная возможность восстановить поврежденную конечность - отпилить ее, чтобы она вновь отрасла в mineral bath. Но с торсом или головой так не получится.

<!-- ЗДЕСЬ нужно **привязать ишью**, которые относятся к PR'у в формате `close #1234` или `fixes #1234` - тогда они автоматически закроются вместе с PR. Можно написать `Затрагивает #1234, но не фиксит его`, если вы просто хотите упоминуть ишью, но не закрывать его. -->
close #0

<!-- ЗДЕСЬ нужно **расписать изменения** которые попадут в **чейнджлог**, формат - `prefix: краткое описание` -->
### Чейнджлог
```yml
🆑Builder13
rscadd: Добавлена единственная возможность чинить переломы для Адхерантов - через минеральные ванны. Процедура может быть длительной.
/🆑
```

<!--
  Честно заполняем галочки. Чем больше галочек, тем быстрее проверять Pull Request, соответственно он быстрее будет принят.
  Чтобы отметить - ставим `x` (икс) внутри квадратных скобочек вот так: `- [x] ...`.
  Галочки можно доставлять позже по мере окончания работы над PR'ом.
-->

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
