### PR TITLE
Быстрый откат лоадаута

### DIFF
--- a/code/_helpers/_global_objects.dm
+++ b/code/_helpers/_global_objects.dm
@@ -7,13 +7,13 @@ var/global/datum/gear_tweak/color/gear_tweak_free_color_choice_
 //#define gear_tweak_free_color_choice (gear_tweak_free_color_choice_ ? gear_tweak_free_color_choice_ : (gear_tweak_free_color_choice_ = new()))
 // Might work in 511 assuming x=y=5 gets implemented.
 
-var/global/datum/gear_tweak/custom_var/name/gear_tweak_free_name_
+var/global/datum/gear_tweak/custom_name/gear_tweak_free_name_
 
 /proc/gear_tweak_free_name()
 	if(!gear_tweak_free_name_) gear_tweak_free_name_ = new()
 	return gear_tweak_free_name_
 
-var/global/datum/gear_tweak/custom_var/desc/gear_tweak_free_desc_
+var/global/datum/gear_tweak/custom_desc/gear_tweak_free_desc_
 
 /proc/gear_tweak_free_desc()
 	if(!gear_tweak_free_desc_) gear_tweak_free_desc_ = new()

--- a/code/modules/client/preference_setup/loadout/_defines.dm
+++ b/code/modules/client/preference_setup/loadout/_defines.dm
@@ -2,6 +2,3 @@
 #define GEAR_HAS_TYPE_SELECTION FLAG(1)
 #define GEAR_HAS_SUBTYPE_SELECTION FLAG(2)
 #define GEAR_HAS_NO_CUSTOMIZATION FLAG(3)
-/// This flag is discouraged for loadout items with random contents.
-/// Extended descriptions are cached and even if they weren't, seeing random descriptions every refresh of the loadout would be odd as well.
-#define GEAR_HAS_EXTENDED_DESCRIPTION FLAG(4)

--- a/code/modules/client/preference_setup/loadout/lists/accessories.dm
+++ b/code/modules/client/preference_setup/loadout/lists/accessories.dm
@@ -65,7 +65,7 @@
 	description = "A medal or ribbon awarded to corporate personnel for significant accomplishments."
 	path = /obj/item/storage/medalbox
 	cost = 6
-	flags = GEAR_HAS_NO_CUSTOMIZATION | GEAR_HAS_EXTENDED_DESCRIPTION
+	flags = GEAR_HAS_NO_CUSTOMIZATION
 
 
 /datum/gear/accessory/ntaward/New()

--- a/code/modules/client/preference_setup/loadout/loadout.dm
+++ b/code/modules/client/preference_setup/loadout/loadout.dm
@@ -191,7 +191,7 @@ var/global/list/gear_datums = list()
 		entry += "<tr style='vertical-align:top;'><td><a style='white-space:normal;' class='[gear_link_class]' href='?src=\ref[src];toggle_gear=\ref[G]'>[G.display_name]</a></td>" //inf, was: entry += "<tr style='vertical-align:top;'><td width=25%><a style='white-space:normal;' [ticked ? "class='linkOn' " : ""]href='?src=\ref[src];toggle_gear=\ref[G]'>[G.display_name]</a></td>"
 		// [/SIERRA-EDIT]
 		entry += "<td width = 10% style='vertical-align:top'>[G.cost]</td>"
-		entry += "<td>[FONT_NORMAL(G.get_description(get_gear_metadata(G,1), ticked))]"
+		entry += "<td>[FONT_NORMAL(G.get_description(get_gear_metadata(G,1)))]"
 		var/allowed = 1
 		if(allowed && G.allowed_roles)
 			var/good_job = 0
@@ -387,10 +387,10 @@ var/global/list/gear_datums = list()
 	if(custom_setup_proc)
 		gear_tweaks += new/datum/gear_tweak/custom_setup(custom_setup_proc)
 
-/datum/gear/proc/get_description(metadata, include_extended_description)
+/datum/gear/proc/get_description(metadata)
 	. = description
 	for(var/datum/gear_tweak/gt in gear_tweaks)
-		. = gt.tweak_description(., metadata["[gt]"], include_extended_description && (flags & GEAR_HAS_EXTENDED_DESCRIPTION))
+		. = gt.tweak_description(., metadata["[gt]"])
 
 /datum/gear_data
 	var/path

--- a/maps/torch/loadout/loadout_accessories.dm
+++ b/maps/torch/loadout/loadout_accessories.dm
@@ -4,7 +4,7 @@
 	path = /obj/item/storage/medalbox/sol
 	cost = 6
 	allowed_branches = SOLGOV_BRANCHES
-	flags = GEAR_HAS_NO_CUSTOMIZATION | GEAR_HAS_EXTENDED_DESCRIPTION
+	flags = GEAR_HAS_NO_CUSTOMIZATION
 
 /datum/gear/accessory/solgov_award_military/New()
 	..()
@@ -24,7 +24,7 @@
 	description = "A selection of civilian awards awarded by the Sol Central Government."
 	path = /obj/item/storage/medalbox/sol
 	cost = 3
-	flags = GEAR_HAS_NO_CUSTOMIZATION | GEAR_HAS_EXTENDED_DESCRIPTION
+	flags = GEAR_HAS_NO_CUSTOMIZATION
 
 /datum/gear/accessory/solgov_award_civilian/New()
 	..()


### PR DESCRIPTION
<!-- ЗДЕСЬ должно быть **подробное описание** того, что происходит в PR и зачем это нужно. PR не должен содержать изменений, о которых здесь ничего не сказано. -->
Вчера был принят этот ПР https://github.com/SierraBay/SierraBay12/pull/2578, на оффах у него уже был откат - https://github.com/Baystation12/Baystation12/pull/34749 (но у нас отката по списку не было). Откат нужен, так как сейчас нельзя ставить кастомное имя и описание к предметам лоадаута. (Например: accessories - dog tags)

<!-- ЗДЕСЬ нужно **привязать ишью**, которые относятся к PR'у в формате `close #1234` или `fixes #1234` - тогда они автоматически закроются вместе с PR. Можно написать `Затрагивает #1234, но не фиксит его`, если вы просто хотите упоминуть ишью, но не закрывать его. -->
close #0

<!-- ЗДЕСЬ нужно **расписать изменения** которые попадут в **чейнджлог**, формат - `prefix: краткое описание` -->
### Чейнджлог
```yml
🆑Builder13
bugfix: Фикс изменения названия и описания для предметов лоадаута
/🆑
```

<!--
  Честно заполняем галочки. Чем больше галочек, тем быстрее проверять Pull Request, соответственно он быстрее будет принят.
  Чтобы отметить - ставим `x` (икс) внутри квадратных скобочек вот так: `- [x] ...`.
  Галочки можно доставлять позже по мере окончания работы над PR'ом.
-->

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
