### PR TITLE
Блокировка обновления зрения

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -3370,6 +3370,7 @@
 #include "mods\_master_files\code\modules\culture_descriptor\religion\religions_unathi.dm"
 #include "mods\_master_files\code\modules\culture_descriptor\religion\religions_vox.dm"
 #include "mods\_master_files\code\modules\events\gravity.dm"
+#include "mods\_master_files\code\modules\mob\living\life.dm"
 #include "mods\_master_files\code\modules\mob\new_player\new_player.dm"
 #include "mods\_master_files\code\modules\overmap\distress.dm"
 #include "mods\_master_files\code\modules\overmap\panicbutton.dm"

--- a/mods/_master_files/code/modules/mob/living/life.dm
+++ b/mods/_master_files/code/modules/mob/living/life.dm
@@ -1,0 +1,8 @@
+//stop sight update
+/mob
+	var/stop_sight_update = FALSE //for update_sight()
+
+/mob/living/update_sight()
+	if(stop_sight_update) return
+	..()
+//


### PR DESCRIPTION
<!-- ЗДЕСЬ должно быть **подробное описание** того, что происходит в PR и зачем это нужно. PR не должен содержать изменений, о которых здесь ничего не сказано. -->
Возвращает возможность блокировать обновление зрения через переменную stop_sight_update у моба. Можно использовать в рамках ивентов и пр. чтобы к примеру дальше поменять переменную see_invisible. (https://github.com/ss220-space/Baystation12/blob/14cec0af0f6dafd5555a6f530ab3113ce5dbac7c/code/modules/mob/living/life.dm#L198)

<!-- ЗДЕСЬ нужно **привязать ишью**, которые относятся к PR'у в формате `close #1234` или `fixes #1234` - тогда они автоматически закроются вместе с PR. Можно написать `Затрагивает #1234, но не фиксит его`, если вы просто хотите упоминуть ишью, но не закрывать его. -->
close #2744

<!-- ЗДЕСЬ нужно **расписать изменения** которые попадут в **чейнджлог**, формат - `prefix: краткое описание` -->
### Чейнджлог
```yml
🆑Builder13
admin: Возвращена переменная stop_sight_update для мобов, чтобы исключить обновление зрения при ее включении
/🆑
```

<!--
  Честно заполняем галочки. Чем больше галочек, тем быстрее проверять Pull Request, соответственно он быстрее будет принят.
  Чтобы отметить - ставим `x` (икс) внутри квадратных скобочек вот так: `- [x] ...`.
  Галочки можно доставлять позже по мере окончания работы над PR'ом.
-->

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
