### PR TITLE
Fixes view Y_decode

### DIFF
--- a/code/_onclick/hud/movable_screen_objects.dm
+++ b/code/_onclick/hud/movable_screen_objects.dm
@@ -60,7 +60,7 @@
 /obj/screen/movable/proc/decode_screen_X(X, mob/viewer)
 	// [SIERRA-EDIT]
 	var/view = viewer.client ? get_view_size_x(viewer.client.view) : get_view_size_x(world.view)
-	var/x_center = ceil(view / 2) + 1 // finding our x center of view
+	var/x_center = floor(view / 2) + 1 // finding our x center of view
 	//Find EAST/WEST implementations
 	if(findtext(X,"EAST-"))
 		var/num = text2num(copytext(X,6)) //Trim EAST-

--- a/code/_onclick/hud/movable_screen_objects.dm
+++ b/code/_onclick/hud/movable_screen_objects.dm
@@ -79,7 +79,7 @@
 /obj/screen/movable/proc/encode_screen_Y(Y, mob/viewer)
 	// [SIERRA-EDIT]
 	var/view = viewer.client ? get_view_size_y(viewer.client.view) : get_view_size_y(world.view)
-	var/y_center = ceil(view / 2) + 1 // finding our y center of view
+	var/y_center = floor(view / 2) + 1 // finding our y center of view
 
 	if(Y > y_center)      // we are on the right side of the view
 		. = "NORTH-[view - Y]"

--- a/code/_onclick/hud/movable_screen_objects.dm
+++ b/code/_onclick/hud/movable_screen_objects.dm
@@ -47,7 +47,7 @@
 /obj/screen/movable/proc/encode_screen_X(X, mob/viewer)
 	// [SIERRA-EDIT]
 	var/view = viewer.client ? get_view_size_x(viewer.client.view) : get_view_size_x(world.view)
-	var/x_center = ceil(view / 2) + 1 // finding our x center of view
+	var/x_center = floor(view / 2) + 1 // finding our x center of view
 
 	if(X > x_center)      // we are on the right side of the view
 		. = "EAST-[view - X]"

--- a/code/_onclick/hud/movable_screen_objects.dm
+++ b/code/_onclick/hud/movable_screen_objects.dm
@@ -92,7 +92,7 @@
 /obj/screen/movable/proc/decode_screen_Y(Y, mob/viewer)
 	// [SIERRA-EDIT]
 	var/view = viewer.client ? get_view_size_y(viewer.client.view) : get_view_size_y(world.view)
-	var/y_center = ceil(view / 2) + 1 // finding our y center of view
+	var/y_center = floor(view / 2) + 1 // finding our y center of view
 
 	if(findtext(Y,"NORTH-"))
 		var/num = text2num(copytext(Y,7)) //Trim NORTH-

--- a/code/_onclick/hud/movable_screen_objects.dm
+++ b/code/_onclick/hud/movable_screen_objects.dm
@@ -45,78 +45,68 @@
 		screen_loc = "[screen_loc_X[1]]:[pix_X],[screen_loc_Y[1]]:[pix_Y]"
 
 /obj/screen/movable/proc/encode_screen_X(X, mob/viewer)
-	var/view = viewer.client ? viewer.client.view : world.view
-	// [SIERRA-ADD]
-	if(view == "19x15")
-		view = 9
-	else if(view == "17x15")
-		view = 8
-	else if(view == "15x15")
-		view = 7
-	// [/SIERRA-ADD]
-	if(X > view+1)
-		. = "EAST-[view*2 + 1-X]"
-	else if(X < view+1)
+	// [SIERRA-EDIT]
+	var/view = viewer.client ? get_view_size_x(viewer.client.view) : get_view_size_x(world.view)
+	var/x_center = ceil(view / 2) + 1 // finding our x center of view
+
+	if(X > x_center)      // we are on the right side of the view
+		. = "EAST-[view - X]"
+	else if(X < x_center) // we are on the left side of the view
 		. = "WEST+[X-1]"
-	else
+	else                  // we are on the center of the view
 		. = "CENTER"
+	// [/SIERRA-EDIT]
 
 /obj/screen/movable/proc/decode_screen_X(X, mob/viewer)
-	var/view = viewer.client ? viewer.client.view : world.view
-	// [SIERRA-ADD]
-	if(view == "19x15")
-		view = 9
-	else if(view == "17x15")
-		view = 8
-	else if(view == "15x15")
-		view = 7
-	// [/SIERRA-ADD]
+	// [SIERRA-EDIT]
+	var/view = viewer.client ? get_view_size_x(viewer.client.view) : get_view_size_x(world.view)
+	var/x_center = ceil(view / 2) + 1 // finding our x center of view
 	//Find EAST/WEST implementations
 	if(findtext(X,"EAST-"))
 		var/num = text2num(copytext(X,6)) //Trim EAST-
 		if(!num)
 			num = 0
-		. = view*2 + 1 - num
+		. = view - num
 	else if(findtext(X,"WEST+"))
 		var/num = text2num(copytext(X,6)) //Trim WEST+
 		if(!num)
 			num = 0
 		. = num+1
 	else if(findtext(X,"CENTER"))
-		. = view+1
+		. = x_center
+	// [/SIERRA-EDIT]
 
 /obj/screen/movable/proc/encode_screen_Y(Y, mob/viewer)
-	var/view = viewer.client ? viewer.client.view : world.view
-	// [SIERRA-ADD]
-	if(view == "19x15" || view == "17x15" || view == "15x15")
-		view = 7
-	// [/SIERRA-ADD]
-	if(Y > view+1)
+	// [SIERRA-EDIT]
+	var/view = viewer.client ? get_view_size_y(viewer.client.view) : get_view_size_y(world.view)
+	var/y_center = ceil(view / 2) + 1 // finding our y center of view
 
-		. = "NORTH-[view*2 + 1-Y]"
-	else if(Y < view+1)
-		. = "SOUTH+[Y-1]"
-	else
+	if(Y > y_center)      // we are on the right side of the view
+		. = "NORTH-[view - Y]"
+	else if(Y < y_center) // we are on the left side of the view
+		. = "SOUTH+[Y - 1]"
+	else                  // we are on the center of the view
 		. = "CENTER"
+	// [/SIERRA-EDIT]
 
 /obj/screen/movable/proc/decode_screen_Y(Y, mob/viewer)
-	var/view = viewer.client ? viewer.client.view : world.view
-	// [SIERRA-ADD]
-	if(view == "19x15" || view == "17x15" || view == "15x15")
-		view = 7
-	// [/SIERRA-ADD]
+	// [SIERRA-EDIT]
+	var/view = viewer.client ? get_view_size_y(viewer.client.view) : get_view_size_y(world.view)
+	var/y_center = ceil(view / 2) + 1 // finding our y center of view
+
 	if(findtext(Y,"NORTH-"))
 		var/num = text2num(copytext(Y,7)) //Trim NORTH-
 		if(!num)
 			num = 0
-		. = view*2 + 1 - num
+		. = view - num
 	else if(findtext(Y,"SOUTH+"))
 		var/num = text2num(copytext(Y,7)) //Time SOUTH+
 		if(!num)
 			num = 0
 		. = num+1
 	else if(findtext(Y,"CENTER"))
-		. = view+1
+		. = y_center
+	// [/SIERRA-EDIT]
 
 //Debug procs
 /client/proc/test_movable_UI()

--- a/code/_onclick/hud/movable_screen_objects.dm
+++ b/code/_onclick/hud/movable_screen_objects.dm
@@ -100,7 +100,7 @@
 		. = "CENTER"
 
 /obj/screen/movable/proc/decode_screen_Y(Y, mob/viewer)
-	var/view = viewer.client ? get_view_size_y(viewer.client.view) : world.view
+	var/view = viewer.client ? viewer.client.view : world.view
 	// [SIERRA-ADD]
 	if(view == "19x15" || view == "17x15" || view == "15x15")
 		view = 7


### PR DESCRIPTION
<!-- ЗДЕСЬ должно быть **подробное описание** того, что происходит в PR и зачем это нужно. PR не должен содержать изменений, о которых здесь ничего не сказано. -->
в #2182 случайно был затронут прок декодировки обзора по вертикали
```diff
-	var/view = viewer.client ? viewer.client.view : world.view
+	var/view = viewer.client ? get_view_size_y(viewer.client.view) : world.view
```
из-за чего происходила ужасная неразбериха и кнопка съезжала на `обзор_по_y * 2 + 1` ( closes #2774 )

переписал на чуть более читабельное, заодно избавившись от хардкода (кнопки не будут ломаться, если у клиента окажется нестандартный обзор)
<!-- ЗДЕСЬ нужно **привязать ишью**, которые относятся к PR'у в формате `close #1234` или `fixes #1234` - тогда они автоматически закроются вместе с PR. Можно написать `Затрагивает #1234, но не фиксит его`, если вы просто хотите упоминуть ишью, но не закрывать его. -->


<!-- ЗДЕСЬ нужно **расписать изменения** которые попадут в **чейнджлог**, формат - `prefix: краткое описание` -->
### Чейнджлог
```yml
🆑NinjaPikachushka
bugfix: Худ-Кнопки мага перестали сбегать.
/🆑
```

<!--
  Честно заполняем галочки. Чем больше галочек, тем быстрее проверять Pull Request, соответственно он быстрее будет принят.
  Чтобы отметить - ставим `x` (икс) внутри квадратных скобочек вот так: `- [x] ...`.
  Галочки можно доставлять позже по мере окончания работы над PR'ом.
-->

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
