### PR TITLE
Особенности гильгамешской охоты (мапфикс)

### DIFF
--- a/mods/_maps/farfleet/maps/farfleet-2.dmm
+++ b/mods/_maps/farfleet/maps/farfleet-2.dmm
@@ -49,6 +49,7 @@
 /area/ship/farfleet/barracks/armory)
 "aO" = (
 /obj/machinery/photocopier,
+/obj/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/ship/farfleet/crew/brig/css)
 "aP" = (
@@ -107,6 +108,9 @@
 	pixel_y = 32
 	},
 /obj/item/stack/package_wrap/cargo_wrap,
+/obj/item/storage/lunchbox/gcc,
+/obj/item/storage/lunchbox/gcc,
+/obj/item/storage/lunchbox/gcc,
 /turf/simulated/floor/tiled/white,
 /area/ship/farfleet/crew/kitchen)
 "bg" = (
@@ -122,6 +126,7 @@
 /obj/machinery/atmospherics/unary/tank/hydrogen{
 	dir = 1
 	},
+/obj/floor_decal/industrial/outline/red,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/ship/farfleet/command/hangar_canisters)
 "br" = (
@@ -388,6 +393,7 @@
 /obj/machinery/atmospherics/unary/tank/carbon_dioxide{
 	dir = 4
 	},
+/obj/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/ship/farfleet/command/hangar_canisters)
 "dY" = (
@@ -441,6 +447,7 @@
 /area/ship/farfleet/crew/freezer)
 "eg" = (
 /obj/machinery/artifact_analyser,
+/obj/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techmaint,
 /area/ship/farfleet/maintenance/anomaly)
 "en" = (
@@ -454,6 +461,7 @@
 /area/ship/farfleet/crew/brig)
 "eo" = (
 /obj/structure/reagent_dispensers/coolanttank,
+/obj/floor_decal/industrial/outline/blue,
 /turf/simulated/floor/tiled/techmaint,
 /area/ship/farfleet/maintenance/anomaly)
 "er" = (
@@ -567,6 +575,7 @@
 /area/ship/farfleet/barracks/armory)
 "fN" = (
 /obj/machinery/photocopier,
+/obj/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techmaint,
 /area/ship/farfleet/maintenance/anomaly)
 "fS" = (
@@ -666,6 +675,7 @@
 	icon_state = "map_connector"
 	},
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/ship/farfleet/command/hangar_canisters)
 "gL" = (
@@ -729,6 +739,7 @@
 /area/ship/farfleet/crew/kitchen)
 "hj" = (
 /obj/structure/closet/radiation,
+/obj/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techmaint,
 /area/ship/farfleet/maintenance/anomaly)
 "hn" = (
@@ -883,6 +894,7 @@
 /area/ship/farfleet/maintenance/anomaly)
 "iv" = (
 /obj/structure/closet/secure_closet/farfleet/css,
+/obj/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/ship/farfleet/crew/brig/css)
 "iG" = (
@@ -1093,8 +1105,8 @@
 /obj/structure/closet/secure_closet/hydroponics{
 	req_access = list()
 	},
-/obj/floor_decal/corner_steel_grid/diagonal,
-/turf/simulated/floor/tiled,
+/obj/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/monotile,
 /area/ship/farfleet/crew/hydroponics)
 "kS" = (
 /obj/machinery/light,
@@ -2380,6 +2392,7 @@
 /area/ship/snz)
 "xk" = (
 /obj/machinery/artifact_harvester,
+/obj/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techmaint,
 /area/ship/farfleet/maintenance/anomaly)
 "xl" = (
@@ -3249,6 +3262,14 @@
 /obj/item/rig_module/grenade_launcher/light,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/ship/farfleet/barracks/armory)
+"Em" = (
+/obj/structure/table/reinforced,
+/obj/item/gun/projectile/shotgun/pump/exploration,
+/obj/item/gun/projectile/shotgun/pump/exploration{
+	pixel_y = 6
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ship/farfleet/barracks)
 "En" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -3838,6 +3859,7 @@
 /area/ship/farfleet/crew/hydroponics)
 "Lf" = (
 /obj/machinery/papershredder,
+/obj/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/ship/farfleet/crew/brig/css)
 "Ll" = (
@@ -4594,6 +4616,13 @@
 /obj/item/clothing/accessory/storage/holster/armpit,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/ship/farfleet/barracks/armory)
+"Tc" = (
+/obj/structure/table/reinforced,
+/obj/item/ammo_magazine/shotholder/net,
+/obj/item/ammo_magazine/shotholder/net,
+/obj/item/ammo_magazine/shotholder/net,
+/turf/simulated/floor/tiled/dark,
+/area/ship/farfleet/barracks)
 "Tg" = (
 /obj/floor_decal/corner/b_green/diagonal{
 	dir = 8
@@ -4742,6 +4771,14 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/ship/farfleet/command/snz_hangar)
+"Uq" = (
+/obj/floor_decal/corner/b_green/diagonal{
+	dir = 8
+	},
+/obj/structure/table/standard,
+/obj/item/storage/lunchbox/gcc,
+/turf/simulated/floor/tiled/white,
+/area/ship/farfleet/crew/canteen)
 "Uu" = (
 /turf/simulated/floor/tiled/dark,
 /area/ship/farfleet/barracks)
@@ -5250,6 +5287,7 @@
 "Yn" = (
 /obj/machinery/atmospherics/portables_connector,
 /obj/machinery/portable_atmospherics/canister/hydrogen,
+/obj/floor_decal/industrial/outline/red,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/ship/farfleet/command/hangar_canisters)
 "Ys" = (
@@ -11575,7 +11613,7 @@ Je
 MT
 VA
 Ac
-Ac
+Uq
 Wd
 Ye
 cO
@@ -14979,7 +15017,7 @@ wt
 PD
 Gb
 kU
-uA
+Tc
 eS
 sh
 rq
@@ -15101,7 +15139,7 @@ wD
 Uu
 ju
 Uu
-uA
+Em
 eS
 sh
 rq

--- a/mods/_maps/liberia/code/liberia_areas.dm
+++ b/mods/_maps/liberia/code/liberia_areas.dm
@@ -73,10 +73,6 @@
 	name = "FTV Liberia - Shower"
 	icon_state = "showroom"
 
-/area/liberia/toiletroom2
-	name = "FTV Liberia - Toilet"
-	icon_state = "toilet"
-
 /area/liberia/bar
 	name = "FTV Liberia - Bar"
 	icon_state = "bar"

--- a/mods/_maps/liberia/maps/liberia.dmm
+++ b/mods/_maps/liberia/maps/liberia.dmm
@@ -2074,6 +2074,7 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
+/obj/floor_decal/industrial/warning/fulltile,
 /turf/simulated/floor/tiled/steel_grid,
 /area/liberia/engineeringlobby)
 "dA" = (
@@ -3762,8 +3763,8 @@
 /turf/simulated/floor/tiled,
 /area/liberia/hallway)
 "gn" = (
-/obj/machinery/door/airlock{
-	name = "Toilet"
+/obj/machinery/door/airlock/civilian{
+	name = "Restroom"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor,
@@ -3987,11 +3988,6 @@
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
-	},
-/obj/structure/cable/blue{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/liberia/toiletroom1)
@@ -4249,22 +4245,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/obj/structure/cable/blue{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /turf/simulated/floor/tiled/freezer,
 /area/liberia/toiletroom1)
 "hc" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
-	},
-/obj/structure/cable/blue{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/liberia/toiletroom1)
@@ -4335,19 +4321,11 @@
 /turf/simulated/floor/wood/walnut,
 /area/liberia/bar)
 "hm" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
-	},
-/obj/structure/cable/blue{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/liberia/toiletroom1)
@@ -6511,6 +6489,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/floor_decal/industrial/warning/fulltile,
 /turf/simulated/floor/tiled/white,
 /area/liberia/medbay)
 "lx" = (
@@ -7712,9 +7691,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/steel_grid,
 /area/liberia/atmos)
-"BC" = (
-/turf/simulated/wall/r_wall/prepainted,
-/area/liberia/toiletroom2)
 "BE" = (
 /obj/floor_decal/borderfloor{
 	dir = 8
@@ -7840,17 +7816,8 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/machinery/power/apc/liberia{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/obj/structure/cable/blue{
-	d2 = 4;
-	icon_state = "0-4"
-	},
 /turf/simulated/floor/tiled/freezer,
-/area/liberia/toiletroom2)
+/area/liberia/toiletroom1)
 "ED" = (
 /obj/floor_decal/techfloor{
 	dir = 8
@@ -7864,22 +7831,14 @@
 /turf/simulated/wall/r_wall/prepainted,
 /area/liberia/dockinghall)
 "EQ" = (
-/obj/machinery/alarm/merchant{
-	pixel_y = 24
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/obj/structure/cable/blue{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/tiled/freezer,
-/area/liberia/toiletroom2)
+/area/liberia/toiletroom1)
 "EZ" = (
 /obj/wallframe_spawn/no_grille,
 /turf/simulated/floor/plating,
@@ -8288,9 +8247,6 @@
 "Lm" = (
 /turf/simulated/wall/prepainted,
 /area/liberia/bridge)
-"Lz" = (
-/turf/simulated/wall/prepainted,
-/area/liberia/toiletroom2)
 "LJ" = (
 /obj/floor_decal/borderfloor{
 	dir = 6
@@ -8727,6 +8683,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
+/obj/floor_decal/industrial/warning/fulltile,
 /turf/simulated/floor/tiled,
 /area/liberia/personellroom1)
 "TB" = (
@@ -8892,9 +8849,9 @@
 	},
 /area/liberia/solar2)
 "VZ" = (
-/obj/machinery/door/airlock{
-	name = "Toilet";
-	dir = 8
+/obj/machinery/door/airlock/civilian{
+	dir = 4;
+	name = "Restroom"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -8902,14 +8859,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/cable/blue{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/freezer,
-/area/liberia/toiletroom2)
+/area/liberia/toiletroom1)
 "Wb" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -30059,9 +30011,9 @@ fI
 qx
 ip
 ro
-Lz
-Lz
-BC
+OA
+OA
+Se
 aa
 aa
 aa
@@ -30261,9 +30213,9 @@ kO
 fY
 kO
 se
-Lz
+OA
 Ez
-BC
+Se
 aa
 aa
 aa
@@ -30463,9 +30415,9 @@ XE
 ff
 yh
 gD
-Lz
+OA
 EQ
-BC
+Se
 aa
 aa
 aa
@@ -30665,9 +30617,9 @@ ip
 LW
 pD
 OA
-Lz
+OA
 VZ
-BC
+Se
 aa
 aa
 aa


### PR DESCRIPTION
Добавляем на "Гарибальди" два дробовика от Ксинерджи (Тау-Вило как-никак рядом, закупать никто не мешает) и два холдера с нетшеллами. 

Также добавляем ланчбоксы в шкаф на кухне + один на стол. 

Кроме того победили дверь в туалет на Либерии. И да, отдельно АПЦ на туалет - жирно. (двери мешала поворачиваться стеклянная стенка перед ней)

![image](https://github.com/user-attachments/assets/c0a17105-257e-40f6-b8a6-5f98af0925ae)


close #2021
close #2654

### Чейнджлог
```yml
🆑LordNest

maptweak: Добавили ГККшникам дробовики для охоты на фауну и ланчбоксы

/🆑
```

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
