### PR TITLE
Фикс мезонных очков

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -3374,6 +3374,7 @@
 #include "mods\_master_files\code\modules\culture_descriptor\religion\religions_vox.dm"
 #include "mods\_master_files\code\modules\events\gravity.dm"
 #include "mods\_master_files\code\modules\mob\living\life.dm"
+#include "mods\_master_files\code\modules\mob\living\carbon\human\human_helpers.dm"
 #include "mods\_master_files\code\modules\mob\new_player\new_player.dm"
 #include "mods\_master_files\code\modules\overmap\distress.dm"
 #include "mods\_master_files\code\modules\overmap\panicbutton.dm"

--- a/mods/_master_files/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/mods/_master_files/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -1,0 +1,5 @@
+/mob/living/carbon/human/has_meson_effect()
+	. = FALSE
+	for(var/obj/screen/equipment_screen in equipment_overlays) // check through our overlays to see if we have any source of the meson overlay
+		if (equipment_screen.color == GLOB.global_hud.meson.color)
+			return TRUE


### PR DESCRIPTION
<!-- ЗДЕСЬ должно быть **подробное описание** того, что происходит в PR и зачем это нужно. PR не должен содержать изменений, о которых здесь ничего не сказано. -->
Больше нельзя получить галлюцинации от суперматерии при активных мезонных очках. Это только наша проблема, на оффах такого нет.

Сделано по примеру того, что было на инфинити https://github.com/ss220-space/Baystation12/blob/14cec0af0f6dafd5555a6f530ab3113ce5dbac7c/code/modules/mob/living/carbon/human/human_helpers.dm#L361-L365

<!-- ЗДЕСЬ нужно **привязать ишью**, которые относятся к PR'у в формате `close #1234` или `fixes #1234` - тогда они автоматически закроются вместе с PR. Можно написать `Затрагивает #1234, но не фиксит его`, если вы просто хотите упоминуть ишью, но не закрывать его. -->
close #0

<!-- ЗДЕСЬ нужно **расписать изменения** которые попадут в **чейнджлог**, формат - `prefix: краткое описание` -->
### Чейнджлог
```yml
🆑Builder13
bugfix: Больше нельзя получить галлюцинации от суперматерии при активных мезонных очках
/🆑
```

<!--
  Честно заполняем галочки. Чем больше галочек, тем быстрее проверять Pull Request, соответственно он быстрее будет принят.
  Чтобы отметить - ставим `x` (икс) внутри квадратных скобочек вот так: `- [x] ...`.
  Галочки можно доставлять позже по мере окончания работы над PR'ом.
-->

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
