### PR TITLE
Небольшое изменение к пси сигналу

### DIFF
--- a/mods/_master_files/code/modules/psionics/events/mini_spasm.dm
+++ b/mods/_master_files/code/modules/psionics/events/mini_spasm.dm
@@ -26,8 +26,9 @@
 /datum/event/minispasm/end()
 	priority_announcement.Announce( \
 		"PRIORITY ALERT: SIGNAL BROADCAST HAS CEASED. Personnel are cleared to resume use of non-hardened radio transmission equipment. Have a nice day.", \
-		"Cuchulain Sensor Array Automated Message", \
-		new_sound = 'packs/infinity/sound/misc/foundation_restore.ogg' )
+		"Cuchulain Sensor Array Automated Message")
+	var/new_sound = 'packs/infinity/sound/misc/foundation_restore.ogg'
+	sound_to(world, sound(new_sound))
 
 /datum/event/minispasm/do_spasm(mob/living/victim, obj/item/device/radio/source)
 	set waitfor = 0


### PR DESCRIPTION
<!-- ЗДЕСЬ должно быть **подробное описание** того, что происходит в PR и зачем это нужно. PR не должен содержать изменений, о которых здесь ничего не сказано. -->
Звук окончательного оповещения теперь также слышен на всех уровнях, как и звук стартового оповещения.

<!-- ЗДЕСЬ нужно **привязать ишью**, которые относятся к PR'у в формате `close #1234` или `fixes #1234` - тогда они автоматически закроются вместе с PR. Можно написать `Затрагивает #1234, но не фиксит его`, если вы просто хотите упоминуть ишью, но не закрывать его. -->
close #0

<!-- ЗДЕСЬ нужно **расписать изменения** которые попадут в **чейнджлог**, формат - `prefix: краткое описание` -->
### Чейнджлог
```yml
🆑Builder13
tweak: Звук окончательного оповещения пси сигнала теперь также слышен на всех уровнях, как и звук стартового оповещения.
/🆑
```

<!--
  Честно заполняем галочки. Чем больше галочек, тем быстрее проверять Pull Request, соответственно он быстрее будет принят.
  Чтобы отметить - ставим `x` (икс) внутри квадратных скобочек вот так: `- [x] ...`.
  Галочки можно доставлять позже по мере окончания работы над PR'ом.
-->

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
