### PR TITLE
Flat age skill poins for some xeno

### DIFF
--- a/mods/adherent_discharge/code/adherent.dm
+++ b/mods/adherent_discharge/code/adherent.dm
@@ -4,6 +4,9 @@
 /obj/item/organ/internal/cell/adherent
 	var/ready_to_charge
 
+/datum/species/adherent/skills_from_age(age)
+	if(age)
+		. = 8
 
 /mob/living/carbon/human/proc/toggle_emergency_discharge()
 	set category = "Abilities"

--- a/mods/diona/code/station.dm
+++ b/mods/diona/code/station.dm
@@ -16,3 +16,7 @@
 	slowdown = 2
 	thirst_factor = 0.06
 	additional_languages = 2
+
+/datum/species/diona/skills_from_age(age)
+	if(age)
+		. = 16

--- a/mods/ipc_mods/code/machine.dm
+++ b/mods/ipc_mods/code/machine.dm
@@ -5,6 +5,10 @@
 	passive_temp_gain = 0  // This should cause IPCs to stabilize at ~80 C in a 20 C environment.(5 is default without organ)
 	additional_languages = 1
 
+/datum/species/machine/skills_from_age(age)
+	if(age)
+		. = 8
+
 /obj/machinery/organ_printer/robot/New()
 	LAZYINITLIST(products)
 	products[BP_COOLING] = list(/obj/item/organ/internal/cooling_system, 35)


### PR DESCRIPTION
<!-- ЗДЕСЬ должно быть **подробное описание** того, что происходит в PR и зачем это нужно. PR не должен содержать изменений, о которых здесь ничего не сказано. -->
Скиллпоинты ИПС, Адхерантов и Дион теперь не зависят от возраста

<!-- ЗДЕСЬ нужно **привязать ишью**, которые относятся к PR'у в формате `close #1234` или `fixes #1234` - тогда они автоматически закроются вместе с PR. Можно написать `Затрагивает #1234, но не фиксит его`, если вы просто хотите упоминуть ишью, но не закрывать его. -->
close #0

<!-- ЗДЕСЬ нужно **расписать изменения** которые попадут в **чейнджлог**, формат - `prefix: краткое описание` -->
### Чейнджлог
```yml
🆑Lexanx
tweak: Скиллпоинты ИПС, Адхерантов и Дион теперь не зависят от возраста
/🆑
```

<!--
  Честно заполняем галочки. Чем больше галочек, тем быстрее проверять Pull Request, соответственно он быстрее будет принят.
  Чтобы отметить - ставим `x` (икс) внутри квадратных скобочек вот так: `- [x] ...`.
  Галочки можно доставлять позже по мере окончания работы над PR'ом.
-->

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
