### PR TITLE
Переключение типа меню (обычное/NanoUI) для входа в игру и манифеста.

### DIFF
--- a/mods/_master_files/code/modules/mob/new_player/new_player.dm
+++ b/mods/_master_files/code/modules/mob/new_player/new_player.dm
@@ -15,10 +15,14 @@
 	return ..()
 
 /mob/new_player/ViewManifest()
+	if(usr.get_preference_value(/datum/client_preference/show_nanoui_start) == GLOB.PREF_NO)
+		return ..()
 	var/datum/nano_module/manifest/ui = new /datum/nano_module/manifest(usr)
 	ui.ui_interact(usr)
 
 /mob/new_player/LateChoices()
+	if(usr.get_preference_value(/datum/client_preference/show_nanoui_start) == GLOB.PREF_NO)
+		return ..()
 	var/datum/nano_module/joinpanel/ui = locate("joinui_[usr.ckey]")
 	if(!ui)
 		ui = new /datum/nano_module/joinpanel(usr)

--- a/mods/newUI/_newUI.dme
+++ b/mods/newUI/_newUI.dme
@@ -8,6 +8,7 @@
 #include "..\_master_files\code\modules\paperwork\photocopier.dm"
 #include "..\_master_files\code\modules\paperwork\faxmachine.dm"
 #include "..\_master_files\code\modules\mob\observer\ghost\ghost.dm"
+#include "code\preferences.dm"
 #include "code\manifest.dm"
 #include "code\joinpanel.dm"
 

--- a/mods/newUI/code/preferences.dm
+++ b/mods/newUI/code/preferences.dm
@@ -1,0 +1,5 @@
+/datum/client_preference/show_nanoui_start
+	description ="Show NanoUI interfaces in start menu"
+	key = "SHOW_NANOUI_START"
+	options = list(GLOB.PREF_YES, GLOB.PREF_NO)
+	default_value = GLOB.PREF_NO


### PR DESCRIPTION
<!-- ЗДЕСЬ должно быть **подробное описание** того, что происходит в PR и зачем это нужно. PR не должен содержать изменений, о которых здесь ничего не сказано. -->
Добавлена возможность отключить (или включить) NanoUI меню входа в игру и манифеста через настройки Character Preferences. По умолчанию стоит в значении NO, то есть будет показываться обычное меню, не NanoUI.
![image](https://github.com/user-attachments/assets/33320b9b-4f2b-43bc-b961-6f83a2a11920)

### Чейнджлог
```yml
🆑FeudeyTF
tweak: Теперь можно выключить или включить NanoUI для меню входа в игру и манифеста через настройки Character Setup (раздел Global, OOC, самый низ, Show NanoUI interfaces int start menu)
/🆑
```

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
