### PR TITLE
Augmented Eyesight fix

### DIFF
--- a/mods/antagonists/_antagonists.dme
+++ b/mods/antagonists/_antagonists.dme
@@ -4,6 +4,7 @@
 #include "_antagonists.dm"
 
 #include "code/blackout.dm"
+#include "code/changeling.dm"
 #include "code/ert.dm"
 #include "code/mercenary.dm"
 #include "code/revolutionary.dm"

--- a/mods/antagonists/code/changeling.dm
+++ b/mods/antagonists/code/changeling.dm
@@ -1,0 +1,9 @@
+/obj/item/organ/internal/augment/ling_lenses/Process()
+	..()
+	if(is_active && (owner.mind.changeling.chem_charges > 0))
+		owner.set_sight(owner.sight | SEE_MOBS)
+		owner.mind.changeling.chem_charges -= 3
+		if(owner.mind.changeling.chem_charges < 3)
+			is_active = FALSE
+			owner.set_sight(owner.sight &= ~SEE_MOBS)
+			to_chat(owner,SPAN_NOTICE("Our lenses retract, causing us to lose our augmented vision."))


### PR DESCRIPTION
ПР заставляет термальное зрение генокрадов выключаться, если хранилище химикатов опустошено

частично фиксит #3037, но не полностью

### Чейнджлог
```yml
🆑nasend_
bugfix: Термальное зрение генокрадов больше не остается навсегда.
/🆑
```

- [ ] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [ ] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
