### PR TITLE
[TWEAK] - Multi-Z space turfs

### DIFF
--- a/maps/sierra/sierra_turfs.dm
+++ b/maps/sierra/sierra_turfs.dm
@@ -22,3 +22,61 @@
 
 /turf/simulated/floor/shuttle_ceiling/sierra/air
 	initial_gas = list("oxygen" = MOLES_O2STANDARD, "nitrogen" = MOLES_N2STANDARD)
+
+/*
+* Z-mimic space turf part
+*/
+
+/proc/GetBelowZlevels(z)
+	RETURN_TYPE(/list)
+	. = list()
+	for(var/level = z, HasBelow(level), level--)
+		. |= level - 1
+
+/proc/GetAboveZlevels(z)
+	RETURN_TYPE(/list)
+	. = list()
+	for(var/level = z, HasAbove(level), level++)
+		. |= level + 1
+
+/turf/space/Initialize()
+	. = ..()
+	update_starlight()
+
+	set_extension(src, /datum/extension/support_lattice)
+
+	if (z_eventually_space)
+		appearance = SSskybox.space_appearance_cache[(((x + y) ^ ~(x * y) + z) % 25) + 1]
+
+	if(!HasBelow(z))
+		return
+	var/turf/below = GetBelow(src)
+
+	if(istype(below, /turf/space))
+		return
+	var/area/A = below.loc
+
+	if(!below.density && (A.area_flags & AREA_FLAG_EXTERNAL))
+		return
+
+	return INITIALIZE_HINT_LATELOAD // oh no! we need to switch to being a different kind of turf!
+
+// Turfs for the non-bottom layers of multi-z space areas
+/turf/space/open
+	icon_state = ""
+	z_flags = ZM_MIMIC_DEFAULTS | ZM_MIMIC_OVERWRITE | ZM_MIMIC_NO_AO
+	z_eventually_space = 0
+
+
+/turf/space/open/Initialize()
+	for (var/level in GetBelowZlevels(z))
+		var/turf/below = locate(x, y, level)
+		if (!istype(below, /turf/space))
+			z_eventually_space = FALSE
+			break
+		if (below.z_eventually_space != 0)
+			z_eventually_space = below.z_eventually_space
+			break
+	if (!z_eventually_space == 0)
+		z_eventually_space = TRUE
+	return ..()


### PR DESCRIPTION
ПР добавляет рубрику "эксперименты" в виде замены кривого опен спейса на новый `/turf/space/open` 

Теоретически закрывает ряд проблем с газами в космосе, чёрными квадратами в космосе и рядом багов освещения. 

Лайт апдейт, поэтому мы меняем не все турфы, а прилегающие

<!-- ЗДЕСЬ нужно **привязать ишью**, которые относятся к PR'у в формате `close #1234` или `fixes #1234` - тогда они автоматически закроются вместе с PR. Можно написать `Затрагивает #1234, но не фиксит его`, если вы просто хотите упоминуть ишью, но не закрывать его. -->
close #1089
close #2291
close #2007

<details>
  <summary>Боевые картинки (палубы c пятой по мостик)</summary>
 
 N.B. Все скриншоты были сделаны с красным фильтром космоса, который сам по себе является очень тёмным. Но данный фильтр гораздо светлее обычного Open Space
 
![image](https://github.com/user-attachments/assets/d3e5d723-6400-4601-baac-dcc3f8171691)
![image](https://github.com/user-attachments/assets/ff2fd093-b84b-4aa5-ae18-fef5d406e81c)
![image](https://github.com/user-attachments/assets/a799cfb5-e4a0-4a16-99a4-2361726cd717)
![image](https://github.com/user-attachments/assets/1eb83d8b-c195-4ca8-a60e-5d1ab77477b7)
![image](https://github.com/user-attachments/assets/e7992923-3384-4cef-9388-88f3b17e80f2)

  
</details>

<!-- ЗДЕСЬ нужно **расписать изменения** которые попадут в **чейнджлог**, формат - `prefix: краткое описание` -->
### Чейнджлог
```yml
🆑LordNest
bugfix: Газы больше не остаются в космосе после выхода из корабля
maptweak: Все турфы опен спейса вне корабля заменены на более светлые (и такие же прозрачные) turf/space/open 
/🆑
```

<!--
  Честно заполняем галочки. Чем больше галочек, тем быстрее проверять Pull Request, соответственно он быстрее будет принят.
  Чтобы отметить - ставим `x` (икс) внутри квадратных скобочек вот так: `- [x] ...`.
  Галочки можно доставлять позже по мере окончания работы над PR'ом.
-->

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.