### PR TITLE
Починка системы Persistence

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -3441,6 +3441,7 @@
 #include "mods\_master_files\code\modules\mob\new_player\new_player.dm"
 #include "mods\_master_files\code\modules\overmap\distress.dm"
 #include "mods\_master_files\code\modules\overmap\panicbutton.dm"
+#include "mods\_master_files\code\modules\persistence\persistence_datum.dm"
 #include "mods\_master_files\code\modules\power\gravitygenerator.dm"
 #include "mods\_master_files\code\modules\projectiles\projectile\bullets.dm"
 #include "mods\_master_files\code\modules\psionics\events\mini_spasm.dm"

--- a/mods/_master_files/code/modules/persistence/persistence_datum.dm
+++ b/mods/_master_files/code/modules/persistence/persistence_datum.dm
@@ -1,0 +1,43 @@
+//Fixes read/write of the persistence files
+/datum/persistent/SetFilename()
+	..()
+	if(name)
+		filename = "data/persistent/[lowertext(GLOB.using_map.path)]-[lowertext(name)].json"
+
+/datum/controller/subsystem/persistence/proc/mapload_track_value(atom/value, track_type)
+
+	var/turf/T = get_turf(value)
+	if(!T)
+		return
+
+	var/area/A = get_area(T)
+	if(!A || (A.area_flags & AREA_FLAG_IS_NOT_PERSISTENT))
+		return
+
+	if(!(T.z in GLOB.using_map.station_levels)) //without !initialized
+		return
+
+	if(!tracking_values[track_type])
+		tracking_values[track_type] = list()
+	tracking_values[track_type] += value
+
+/datum/persistent/paper/CreateEntryInstance(turf/creating, list/tokens)
+	var/obj/structure/noticeboard/board = locate() in creating
+	if(requires_noticeboard && LAZYLEN(board.notices) >= board.max_notices)
+		return
+	var/obj/item/paper/paper = new paper_type(creating)
+	paper.set_content(tokens["message"], tokens["title"])
+	paper.last_modified_ckey = tokens["author"]
+	if(requires_noticeboard)
+		board.add_paper(paper)
+	SSpersistence.mapload_track_value(paper, type)
+	return paper
+
+/datum/persistent/filth/CreateEntryInstance(turf/creating, list/tokens)
+	var/_path = tokens["path"]
+	var/obj/filth = new _path(creating, tokens["age"]+1)
+	SSpersistence.mapload_track_value(filth, type)
+
+/datum/persistent/graffiti/CreateEntryInstance(turf/creating, list/tokens)
+	var/obj/decal/w = new /obj/decal/writing(creating, tokens["age"]+1, tokens["message"], tokens["author"])
+	SSpersistence.mapload_track_value(w, type)


### PR DESCRIPTION
<!-- ЗДЕСЬ должно быть **подробное описание** того, что происходит в PR и зачем это нужно. PR не должен содержать изменений, о которых здесь ничего не сказано. -->
Чинит систему Persistence, которая переносит заметки, грязь, стикеры, граффити в следующие раунды.

Изначальная строка сейчас: filename = "data/persistent/[lowertext(GLOB.using_map.name)]-[lowertext(name)].json"

GLOB.using_map.name ломает запись и чтение файла, скорее из-за 'improper'. По итогу сейчас название файла никак не меняется по сравнению с тем что раньше было, но теперь оно рабочее.

<!-- ЗДЕСЬ нужно **привязать ишью**, которые относятся к PR'у в формате `close #1234` или `fixes #1234` - тогда они автоматически закроются вместе с PR. Можно написать `Затрагивает #1234, но не фиксит его`, если вы просто хотите упоминуть ишью, но не закрывать его. -->
close #0

<!-- ЗДЕСЬ нужно **расписать изменения** которые попадут в **чейнджлог**, формат - `prefix: краткое описание` -->
### Чейнджлог
```yml
🆑Builder13
bugfix: Система Persistence (перенос грязи и заметок между раундами) вновь должна работать
/🆑
```

<!--
  Честно заполняем галочки. Чем больше галочек, тем быстрее проверять Pull Request, соответственно он быстрее будет принят.
  Чтобы отметить - ставим `x` (икс) внутри квадратных скобочек вот так: `- [x] ...`.
  Галочки можно доставлять позже по мере окончания работы над PR'ом.
-->

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
