### PR TITLE
Фикс атмосферы авеек

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -3438,6 +3438,7 @@
 #include "mods\_master_files\code\modules\culture_descriptor\religion\religions_unathi.dm"
 #include "mods\_master_files\code\modules\culture_descriptor\religion\religions_vox.dm"
 #include "mods\_master_files\code\modules\events\gravity.dm"
+#include "mods\_master_files\code\modules\maps\map_template.dm"
 #include "mods\_master_files\code\modules\mob\living\life.dm"
 #include "mods\_master_files\code\modules\mob\living\carbon\human\human_helpers.dm"
 #include "mods\_master_files\code\modules\mob\new_player\new_player.dm"

--- a/mods/_master_files/code/modules/maps/map_template.dm
+++ b/mods/_master_files/code/modules/maps/map_template.dm
@@ -1,0 +1,25 @@
+//Fix for atmospherics of lateloaded away sites, keeps suspend for the entire process
+/datum/map_template
+	var/air_suspended = FALSE
+	var/airflow_suspended = FALSE
+
+/datum/map_template/init_atoms(list/atoms)
+	if(GAME_STATE >= RUNLEVEL_GAME)
+		if(!SSair.suspended)
+			SSair.suspend()
+			air_suspended = TRUE
+
+		if(!SSairflow.suspended)
+			SSairflow.suspend()
+			airflow_suspended = TRUE
+	..()
+
+/datum/map_template/init_atoms(list/atoms)
+	..()
+	if(air_suspended)
+		SSair.wake()
+		air_suspended = FALSE
+
+	if(airflow_suspended)
+		SSairflow.wake()
+		airflow_suspended = FALSE


### PR DESCRIPTION
<!-- ЗДЕСЬ должно быть **подробное описание** того, что происходит в PR и зачем это нужно. PR не должен содержать изменений, о которых здесь ничего не сказано. -->
Не связано с изменениями по освещению. Во время тестирования теней отдельно заметил что воздух продолжает утекать у авеек при спавне после раундстарта, даже с текущей паузой подсистем воздуха. Расширил паузу подсистем воздуха до полной прогрузки карты.

<!-- ЗДЕСЬ нужно **привязать ишью**, которые относятся к PR'у в формате `close #1234` или `fixes #1234` - тогда они автоматически закроются вместе с PR. Можно написать `Затрагивает #1234, но не фиксит его`, если вы просто хотите упоминуть ишью, но не закрывать его. -->
close #0

<!-- ЗДЕСЬ нужно **расписать изменения** которые попадут в **чейнджлог**, формат - `prefix: краткое описание` -->
### Чейнджлог
```yml
🆑Builder13
bugfix: Атмосфера авеек больше не должна утекать при спавне после раундстарта
/🆑
```

<!--
  Честно заполняем галочки. Чем больше галочек, тем быстрее проверять Pull Request, соответственно он быстрее будет принят.
  Чтобы отметить - ставим `x` (икс) внутри квадратных скобочек вот так: `- [x] ...`.
  Галочки можно доставлять позже по мере окончания работы над PR'ом.
-->

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
