### PR TITLE
Возврат оверлеев газов

### DIFF
--- a/code/modules/xgm/xgm_gas_mixture.dm
+++ b/code/modules/xgm/xgm_gas_mixture.dm
@@ -91,12 +91,12 @@
 	if(!giver)
 		return
 
-	if(abs(temperature-giver.temperature) > MINIMUM_TEMPERATURE_DELTA_TO_CONSIDER)
+	if(abs(temperature-giver.temperature)>MINIMUM_TEMPERATURE_DELTA_TO_CONSIDER)
 		var/self_heat_capacity = heat_capacity()
 		var/giver_heat_capacity = giver.heat_capacity()
 		var/combined_heat_capacity = giver_heat_capacity + self_heat_capacity
 		if(combined_heat_capacity != 0)
-			temperature = (giver.temperature * giver_heat_capacity + temperature*self_heat_capacity) / combined_heat_capacity
+			temperature = (giver.temperature*giver_heat_capacity + temperature*self_heat_capacity)/combined_heat_capacity
 
 	if((group_multiplier != 1)||(giver.group_multiplier != 1))
 		for(var/g in giver.gas)
@@ -346,73 +346,60 @@
 //Rechecks the gas_mixture and adjusts the graphic list if needed.
 //Two lists can be passed by reference if you need know specifically which graphics were added and removed.
 /datum/gas_mixture/proc/check_tile_graphic(list/graphic_add = null, list/graphic_remove = null)
-	for(var/obj/gas_overlay/gas_overlay in graphic)
-		if(istype(gas_overlay, /obj/gas_overlay/heat))
+	for(var/obj/gas_overlay/O in graphic)
+		if(istype(O, /obj/gas_overlay/heat))
 			continue
-
-		if(istype(gas_overlay, /obj/gas_overlay/cold))
+		if(istype(O, /obj/gas_overlay/cold))
 			continue
-
-		if(gas[gas_overlay.gas_id] <= gas_data.overlay_limit[gas_overlay.gas_id])
-			LAZYADD(graphic_remove, gas_overlay)
-
-	var/should_generate_temp_overlay = FALSE
-	for(var/gas_id in gas_data.overlay_limit)
+		if(gas[O.gas_id] <= gas_data.overlay_limit[O.gas_id])
+			LAZYADD(graphic_remove, O)
+	for(var/g in gas_data.overlay_limit)
 		//Overlay isn't applied for this gas, check if it's valid and needs to be added.
-		if(gas[gas_id] > gas_data.overlay_limit[gas_id])
-			should_generate_temp_overlay = TRUE
-			var/tile_overlay = get_tile_overlay(gas_id)
+		if(gas[g] > gas_data.overlay_limit[g])
+			var/tile_overlay = get_tile_overlay(g)
 			if(!(tile_overlay in graphic))
 				LAZYADD(graphic_add, tile_overlay)
-	. = FALSE
+	. = 0
 
-	if(should_generate_temp_overlay)
-		var/heat_overlay = get_tile_overlay(GAS_HEAT)
-		//If it's hot add something
-		if(temperature >= CARBON_LIFEFORM_FIRE_RESISTANCE)
-			if(!(heat_overlay in graphic))
-				LAZYADD(graphic_add, heat_overlay)
-		else if (heat_overlay in graphic)
-			LAZYADD(graphic_remove, heat_overlay)
+	var/heat_overlay = get_tile_overlay(GAS_HEAT)
+	//If it's hot add something
+	if(temperature >= CARBON_LIFEFORM_FIRE_RESISTANCE)
+		if(!(heat_overlay in graphic))
+			LAZYADD(graphic_add, heat_overlay)
+	else if (heat_overlay in graphic)
+		LAZYADD(graphic_remove, heat_overlay)
 
-		var/cold_overlay = get_tile_overlay(GAS_COLD)
-		if(temperature <= FOGGING_TEMPERATURE && (return_pressure() >= (ONE_ATMOSPHERE / 4)))
-			if(!(cold_overlay in graphic))
-				LAZYADD(graphic_add, cold_overlay)
-		else if (cold_overlay in graphic)
-			LAZYADD(graphic_remove, cold_overlay)
+	var/cold_overlay = get_tile_overlay(GAS_COLD)
+	if(temperature <= FOGGING_TEMPERATURE && (return_pressure() >= (ONE_ATMOSPHERE / 4)))
+		if(!(cold_overlay in graphic))
+			LAZYADD(graphic_add, cold_overlay)
+	else if (cold_overlay in graphic)
+		LAZYADD(graphic_remove, cold_overlay)
 
 	//Apply changes
 	if(graphic_add && length(graphic_add))
 		graphic |= graphic_add
-		. = TRUE
-
+		. = 1
 	if(graphic_remove && length(graphic_remove))
 		graphic -= graphic_remove
-		. = TRUE
-
-	if(!length(graphic))
-		return .
-
-	var/pressure_mod = clamp(return_pressure() / ONE_ATMOSPHERE, 0, 2)
-	for(var/obj/gas_overlay/overlay in graphic)
-		if(istype(overlay, /obj/gas_overlay/heat)) //Heat based
-			var/new_alpha = clamp(max(125, 255 * ((temperature - CARBON_LIFEFORM_FIRE_RESISTANCE) / CARBON_LIFEFORM_FIRE_RESISTANCE * 4)), 125, 255)
-			if(new_alpha != overlay.alpha)
-				overlay.update_alpha_animation(new_alpha)
-			continue
-
-		if(istype(overlay, /obj/gas_overlay/cold))
-			var/new_alpha = clamp(max(125, 200 * (1 - ((temperature - MAX_FOG_TEMPERATURE) / (FOGGING_TEMPERATURE - MAX_FOG_TEMPERATURE)))), 125, 200)
-			if(new_alpha != overlay.alpha)
-				overlay.update_alpha_animation(new_alpha)
-			continue
-
-		var/concentration_mod = clamp(gas[overlay.gas_id] / total_moles, 0.1, 1)
-		var/new_alpha = min(230, round(pressure_mod * concentration_mod * 180, 5))
-		if(new_alpha != overlay.alpha)
-			overlay.update_alpha_animation(new_alpha)
-
+		. = 1
+	if(length(graphic))
+		var/pressure_mod = clamp(return_pressure() / ONE_ATMOSPHERE, 0, 2)
+		for(var/obj/gas_overlay/O in graphic)
+			if(istype(O, /obj/gas_overlay/heat)) //Heat based
+				var/new_alpha = clamp(max(125, 255 * ((temperature - CARBON_LIFEFORM_FIRE_RESISTANCE) / CARBON_LIFEFORM_FIRE_RESISTANCE * 4)), 125, 255)
+				if(new_alpha != O.alpha)
+					O.update_alpha_animation(new_alpha)
+				continue
+			if(istype(O, /obj/gas_overlay/cold))
+				var/new_alpha = clamp(max(125, 200 * (1 - ((temperature - MAX_FOG_TEMPERATURE) / (FOGGING_TEMPERATURE - MAX_FOG_TEMPERATURE)))), 125, 200)
+				if(new_alpha != O.alpha)
+					O.update_alpha_animation(new_alpha)
+				continue
+			var/concentration_mod = clamp(gas[O.gas_id] / total_moles, 0.1, 1)
+			var/new_alpha = min(230, round(pressure_mod * concentration_mod * 180, 5))
+			if(new_alpha != O.alpha)
+				O.update_alpha_animation(new_alpha)
 
 /datum/gas_mixture/proc/get_tile_overlay(gas_id)
 	if(!LAZYACCESS(tile_overlay_cache, gas_id))

--- a/maps/sierra/sierra.dm
+++ b/maps/sierra/sierra.dm
@@ -211,7 +211,6 @@
 	#include "../../mods/screentips/_screentips_includes.dm"
 	#include "../../mods/tajara/_tajara_includes.dm"
 	#include "../../mods/sauna_props/_sauna_props_includes.dm"
-	#include "../../mods/wyccbay_optimization/_wyccbay_optimization_includes.dm"
 	#include "../../mods/contraband_vending/_contraband_vending_includes.dm"
 	#include "../../mods/telecomms/_telecomms_includes.dm"
 	#include "../../mods/modernUI/_modernUI_includes.dm"
@@ -221,6 +220,7 @@
 
 	// #include "../../mods/atmos_ret_field/_atm_ret_field.dme"
 	// #include "../../mods/bluespace_kitty/_bluespace_kitty.dme"
+	// #include "../../mods/wyccbay_optimization/_wyccbay_optimization_includes.dm"
 
 	// Почему UNUSED MODS стоит хранить?
 	// Потому что никто не проверяет использование тех или иных файлов

--- a/mods/dev_mode/code/dev_map/_dev_map.dm
+++ b/mods/dev_mode/code/dev_map/_dev_map.dm
@@ -148,7 +148,6 @@
 	#include "../../../../mods/screentips/_screentips_includes.dm"
 	#include "../../../../mods/tajara/_tajara_includes.dm"
 	#include "../../../../mods/sauna_props/_sauna_props_includes.dm"
-	#include "../../../../mods/wyccbay_optimization/_wyccbay_optimization_includes.dm"
 	#include "../../../../mods/contraband_vending/_contraband_vending_includes.dm"
 	#include "../../../../mods/telecomms/_telecomms_includes.dm"
 	#include "../../../../mods/modernUI/_modernUI_includes.dm"
@@ -158,6 +157,7 @@
 
 	// #include "../../mods/atmos_ret_field/_atm_ret_field.dme"
 	// #include "../../mods/bluespace_kitty/_bluespace_kitty.dme"
+	// #include "../../../../mods/wyccbay_optimization/_wyccbay_optimization_includes.dm"
 
 	// Почему UNUSED MODS стоит хранить?
 	// Потому что никто не проверяет использование тех или иных файлов


### PR DESCRIPTION
<!-- ЗДЕСЬ должно быть **подробное описание** того, что происходит в PR и зачем это нужно. PR не должен содержать изменений, о которых здесь ничего не сказано. -->
Возвращает оверлеи газов. xgm_gas_mixture.dm полностью взят с текущего Бея.

Я так понял, что оверлеи отключали из-за одного бага, при котором оверлей горения оставался у тайлов навсегда.
Это сейчас можно проверить так:
1. Отключить мод, но при этом не менять xgm_gas_mixture.dm
2. Заспавнить канистру с фороном рядом с шлюзом для выхода в космос Брига и открыть (в технических помещениях)
3. Поджечь атмосферу и дождаться оверлея горения
4. Открыть шлюзы в космос и дождаться пока будет нулевое давление
5. Нулевое давление достигнуто, но эффект горения все еще остается. Можно также после этого вновь заполнить помещение воздухом и восстановить температуру, но оверлей все так и остается навсегда.

С изменением xgm_gas_mixture.dm эта проблема решается.

<!-- ЗДЕСЬ нужно **привязать ишью**, которые относятся к PR'у в формате `close #1234` или `fixes #1234` - тогда они автоматически закроются вместе с PR. Можно написать `Затрагивает #1234, но не фиксит его`, если вы просто хотите упоминуть ишью, но не закрывать его. -->
close #0

<!-- ЗДЕСЬ нужно **расписать изменения** которые попадут в **чейнджлог**, формат - `prefix: краткое описание` -->
### Чейнджлог
```yml
🆑Builder13
tweak: Возвращены оверлеи газов
/🆑
```

<!--
  Честно заполняем галочки. Чем больше галочек, тем быстрее проверять Pull Request, соответственно он быстрее будет принят.
  Чтобы отметить - ставим `x` (икс) внутри квадратных скобочек вот так: `- [x] ...`.
  Галочки можно доставлять позже по мере окончания работы над PR'ом.
-->

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
