### PR TITLE
Vox walls color fix

### DIFF
--- a/code/game/turfs/simulated/wall_types.dm
+++ b/code/game/turfs/simulated/wall_types.dm
@@ -15,6 +15,8 @@
 /turf/simulated/wall/r_wall/hull/vox
 	initial_gas = list("nitrogen" = 101.38)
 	color = COLOR_GREEN_GRAY
+	paint_color = COLOR_GREEN_GRAY
+	stripe_color = COLOR_GREEN_GRAY
 
 /turf/simulated/wall/prepainted
 	color = COLOR_WALL_GUNMETAL


### PR DESCRIPTION
Фиксим цвет воксовского корабля с солбоевского на зелёную шаху

Не модульно по причине "я дублирую это на оффы"

### Чейнджлог
```yml
🆑LordNest
bugfix: Воксы снова зелёные
/🆑
```

<!--
  Честно заполняем галочки. Чем больше галочек, тем быстрее проверять Pull Request, соответственно он быстрее будет принят.
  Чтобы отметить - ставим `x` (икс) внутри квадратных скобочек вот так: `- [x] ...`.
  Галочки можно доставлять позже по мере окончания работы над PR'ом.
-->

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
