### PR TITLE
Фикс активации позитронки и призыва фамильяра

### DIFF
--- a/code/modules/ghosttrap/trap.dm
+++ b/code/modules/ghosttrap/trap.dm
@@ -37,22 +37,23 @@ var/global/list/ghost_traps
 	..()
 
 // Check for bans, proper atom types, etc.
-/datum/ghosttrap/proc/assess_candidate(mob/observer/ghost/candidate, mob/target, feedback = TRUE)
-	if (!target)
-		to_chat(candidate, "This occupation request is no longer valid.")
-		return FALSE
+/datum/ghosttrap/proc/assess_candidate(mob/observer/ghost/candidate, mob/target, feedback = TRUE, no_target = FALSE)
+	if(!no_target)
+		if (!target)
+			to_chat(candidate, "This occupation request is no longer valid.")
+			return FALSE
+
+		if(request_timeouts[target] && world.time > request_timeouts[target])
+			if (feedback)
+				to_chat(candidate, "This occupation request is no longer valid.")
+			return FALSE
+
+		if(target.key)
+			if (feedback)
+				to_chat(candidate, "The target is already occupied.")
+			return FALSE
 
 	if(!candidate.MayRespawn(feedback, minutes_since_death))
-		return FALSE
-
-	if(request_timeouts[target] && world.time > request_timeouts[target])
-		if (feedback)
-			to_chat(candidate, "This occupation request is no longer valid.")
-		return FALSE
-
-	if(target.key)
-		if (feedback)
-			to_chat(candidate, "The target is already occupied.")
 		return FALSE
 
 	if(islist(ban_checks))

--- a/code/modules/organs/internal/species/ipc.dm
+++ b/code/modules/organs/internal/species/ipc.dm
@@ -34,8 +34,11 @@
 
 /obj/item/organ/internal/posibrain/Initialize()
 	. = ..()
-	if(!brainmob && iscarbon(loc))
-		init(loc)
+	if(!brainmob)
+		if(iscarbon(loc))
+			init(loc)
+		else
+			brainmob = new(src)
 // [SIERRA-REMOVE] - IPC_MODS
 /*
 	unshackle()
@@ -164,7 +167,7 @@
 	if (brainmob.mind && brainmob.mind.special_role)
 		return
 	var/datum/ghosttrap/T = get_ghost_trap("positronic brain")
-	if (!T.assess_candidate(user))
+	if (!T.assess_candidate(user, brainmob))
 		return
 	var/possess = alert(user, "Do you wish to become \the [src]?", "Become [src]?", "Yes", "No")
 	if (possess != "Yes")

--- a/code/modules/spells/artifacts/spellbound_servants.dm
+++ b/code/modules/spells/artifacts/spellbound_servants.dm
@@ -206,10 +206,11 @@
 /obj/cleanable/spellbound/attack_hand(mob/user)
 	if(last_called > world.time )
 		return
+	visible_message(SPAN_WARNING("\The [src] pulses with a small burst of light, for a few seconds."))
 	last_called = world.time + 30 SECONDS
 	var/datum/ghosttrap/G = get_ghost_trap("wizard familiar")
 	for(var/mob/observer/ghost/ghost in GLOB.player_list)
-		if(G.assess_candidate(ghost,null,FALSE))
+		if(G.assess_candidate(ghost,null,FALSE,TRUE))
 			to_chat(ghost,"[SPAN_NOTICE("<b>A wizard is requesting a Spell-Bound Servant!</b>")] (<a href='byond://?src=\ref[src];master=\ref[user]'>Join</a>)")
 
 /obj/cleanable/spellbound/CanUseTopic(mob)

--- a/mods/ipc_mods/code/ipc.dm
+++ b/mods/ipc_mods/code/ipc.dm
@@ -24,31 +24,6 @@
 			return
 		start_search(user)
 
-/obj/item/organ/internal/posibrain/start_search(mob/user)
-	if (brainmob)
-		return
-	if (user)
-		if ((world.time - last_search) < (30 SECONDS))
-			to_chat(user, SPAN_WARNING("\The [src] doesn't react; wait a few seconds before trying again."))
-			return
-		last_search = world.time
-		if (brainmob && brainmob.key)
-			var/murder = alert(user, "\The [src] already has a mind! Are you sure? This is probably murder.", "Commit Robocide?", "Yes", "No")
-			if (murder == "No")
-				return
-		visible_message("\The [user] flicks the activation switch on \the [src].", range = 3)
-	var/has_mind = brainmob && brainmob.key && brainmob.mind
-	var/protected = has_mind && brainmob.mind.special_role
-	if (has_mind)
-		var/actor = user ? "\The [user]" : "Your brain"
-		var/sneaky = protected ? "However, you are beyond such things." : "This might be the end!"
-		to_chat(brainmob, SPAN_WARNING("[actor] is trying to overwrite you! [sneaky]"))
-	if (!protected)
-		var/datum/ghosttrap/T = get_ghost_trap("positronic brain")
-		T.request_player(brainmob, "Someone is requesting a personality for a positronic brain.", 60 SECONDS)
-	searching = addtimer(new Callback(src, PROC_REF(cancel_search)), 60 SECONDS, TIMER_UNIQUE | TIMER_STOPPABLE)
-	icon_state = "posibrain-searching"
-
 /obj/item/organ/internal/posibrain/ipc
 	name = "Positronic brain"
 	desc = "A cube of shining metal, four inches to a side and covered in shallow grooves."


### PR DESCRIPTION
<!-- ЗДЕСЬ должно быть **подробное описание** того, что происходит в PR и зачем это нужно. PR не должен содержать изменений, о которых здесь ничего не сказано. -->
Фиксит активацию позитронного мозга с учетом текущих оверрайдов, фиксит руну призыва фамильяра у мага. Заменяет https://github.com/Baystation12/Baystation12/pull/35336 и https://github.com/Baystation12/Baystation12/pull/35345

<!-- ЗДЕСЬ нужно **привязать ишью**, которые относятся к PR'у в формате `close #1234` или `fixes #1234` - тогда они автоматически закроются вместе с PR. Можно написать `Затрагивает #1234, но не фиксит его`, если вы просто хотите упоминуть ишью, но не закрывать его. -->
close #3927

<!-- ЗДЕСЬ нужно **расписать изменения** которые попадут в **чейнджлог**, формат - `prefix: краткое описание` -->
### Чейнджлог
```yml
🆑Builder13
bugfix: Позитронные мозги теперь можно активировать.
bugfix: Фикс руны призыва фамильяра у мага.
/🆑
```

<!--
  Честно заполняем галочки. Чем больше галочек, тем быстрее проверять Pull Request, соответственно он быстрее будет принят.
  Чтобы отметить - ставим `x` (икс) внутри квадратных скобочек вот так: `- [x] ...`.
  Галочки можно доставлять позже по мере окончания работы над PR'ом.
-->

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
