### PR TITLE
Фикс превью лоадаута

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -3454,6 +3454,7 @@
 #include "mods\_master_files\code\game\objects\structures\signs.dm"
 #include "mods\_master_files\code\game\objects\structures\crates_lockers\closets\_closet_appearance_definitions.dm"
 #include "mods\_master_files\code\modules\client\preferences_persist.dm"
+#include "mods\_master_files\code\modules\client\preference_setup\loadout\loadout.dm"
 #include "mods\_master_files\code\modules\clothing\spacesuits\spacesuits.dm"
 #include "mods\_master_files\code\modules\clothing\under\accessories\armor_plate.dm"
 #include "mods\_master_files\code\modules\culture_descriptor\_culture.dm"

--- a/mods/_master_files/code/modules/client/preference_setup/loadout/loadout.dm
+++ b/mods/_master_files/code/modules/client/preference_setup/loadout/loadout.dm
@@ -1,0 +1,5 @@
+//instant loadout previews regardless of chosen gear and their equip time
+/datum/gear/spawn_on_mob(mob/living/carbon/human/H, metadata)
+	var/obj/item/item = spawn_item(H, H, metadata)
+	if(H.equip_to_slot_if_possible(item, slot, TRYEQUIP_REDRAW | TRYEQUIP_DESTROY | TRYEQUIP_FORCE | TRYEQUIP_INSTANT)) //added TRYEQUIP_INSTANT
+		. = item


### PR DESCRIPTION
<!-- ЗДЕСЬ должно быть **подробное описание** того, что происходит в PR и зачем это нужно. PR не должен содержать изменений, о которых здесь ничего не сказано. -->
Оверрайдит спавн предметов лоадаута, чтобы дать ему флаг мгновенного спавна. Это необходимо для превью лоадаута, так как например пустой плитник из раздела тактики перенимает задержку на надевание в 2 секунды и эти 2 секунды тормозит отрисовку превью лоадаута. Особенно заметно в сочетании с кнопкой Cycle Dir.

<!-- ЗДЕСЬ нужно **привязать ишью**, которые относятся к PR'у в формате `close #1234` или `fixes #1234` - тогда они автоматически закроются вместе с PR. Можно написать `Затрагивает #1234, но не фиксит его`, если вы просто хотите упоминуть ишью, но не закрывать его. -->
close #0

<!-- ЗДЕСЬ нужно **расписать изменения** которые попадут в **чейнджлог**, формат - `prefix: краткое описание` -->
### Чейнджлог
```yml
🆑Builder13
tweak: Задержка надевания предмета больше не задерживает отрисовку превью лоадаута.
/🆑
```

<!--
  Честно заполняем галочки. Чем больше галочек, тем быстрее проверять Pull Request, соответственно он быстрее будет принят.
  Чтобы отметить - ставим `x` (икс) внутри квадратных скобочек вот так: `- [x] ...`.
  Галочки можно доставлять позже по мере окончания работы над PR'ом.
-->

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
