### PR TITLE
Миррор 35354

### DIFF
--- a/code/_helpers/medical_scans.dm
+++ b/code/_helpers/medical_scans.dm
@@ -11,9 +11,9 @@
 	var/brain_result
 	if(H.should_have_organ(BP_BRAIN))
 		var/obj/item/organ/internal/brain/brain = H.internal_organs_by_name[BP_BRAIN]
-		if(!brain || H.stat == DEAD || (H.status_flags & FAKEDEATH))
+		if(!brain || H.is_dead())
 			brain_result = 0
-		else if(H.stat != DEAD)
+		else if(!H.is_dead())
 			brain_result = round(max(0,(1 - brain.damage/brain.max_damage)*100))
 	else
 		brain_result = -1

--- a/code/controllers/subsystems/presence.dm
+++ b/code/controllers/subsystems/presence.dm
@@ -22,7 +22,7 @@ SUBSYSTEM_DEF(presence)
 	var/cut_until = 1
 	for (var/mob/living/player as anything in GLOB.living_players)
 		++cut_until
-		if (QDELETED(player) || player.stat == DEAD)
+		if (QDELETED(player) || player.is_real_dead())
 			continue
 		++build["[get_z(player)]"]
 		if (no_mc_tick)

--- a/code/datums/communication/ooc.dm
+++ b/code/datums/communication/ooc.dm
@@ -13,7 +13,7 @@
 		return
 
 	if(!C.holder)
-		if(!config.dooc_allowed && (C.mob.stat == DEAD))
+		if(!config.dooc_allowed && (C.mob.is_real_dead()))
 			to_chat(C, SPAN_DANGER("[name] for dead mobs has been turned off."))
 			return FALSE
 

--- a/code/datums/extensions/on_click/on_alt_click.dm
+++ b/code/datums/extensions/on_click/on_alt_click.dm
@@ -6,7 +6,8 @@
 /datum/extension/on_click/alt/ghost_admin_killer/New(host, death_proc)
 	..()
 	living_holder = host
-	src.death_proc = death_proc || /mob/proc/death
+	if (death_proc)
+		src.death_proc = death_proc
 
 /datum/extension/on_click/alt/ghost_admin_killer/Destroy()
 	living_holder = null
@@ -38,7 +39,7 @@
 	if(!living_holder.client)                 // And only if the target mob is currently possessed
 		to_chat(user, SPAN_NOTICE("\The [living_holder] is not currently possessed."))
 		return FALSE
-	if(living_holder.stat == DEAD)            // No point in killing the already dead
+	if(living_holder.is_real_dead())            // No point in killing the already dead
 		to_chat(user, SPAN_NOTICE("\The [living_holder] is already dead."))
 		return FALSE
 	return TRUE

--- a/code/game/antagonist/antagonist_helpers.dm
+++ b/code/game/antagonist/antagonist_helpers.dm
@@ -43,7 +43,7 @@
 	var/active_antags = 0
 	for(var/datum/mind/player in current_antagonists)
 		var/mob/living/L = player.current
-		if(!L || L.stat == DEAD)
+		if(!L || L.is_real_dead())
 			continue //no mob or dead
 		if(!L.client && !L.teleop)
 			continue //SSD

--- a/code/game/antagonist/antagonist_panel.dm
+++ b/code/game/antagonist/antagonist_panel.dm
@@ -29,7 +29,7 @@
 		if(M)
 			dat += "<td><a href='byond://?_src_=holder;adminplayeropts=\ref[M]'>[M.real_name]/([player.key])</a>"
 			if(!M.client)      dat += " <i>(logged out)</i>"
-			if(M.stat == DEAD) dat += " <b>[SPAN_COLOR("red", "(DEAD)")]</b>"
+			if(M.is_real_dead()) dat += " <b>[SPAN_COLOR("red", "(DEAD)")]</b>"
 			dat += "</td>"
 			dat += "<td>\[<A href='byond://?src=\ref[calling_admin];priv_msg=\ref[M]'>PM</A>\]\[<A href='byond://?src=\ref[calling_admin];traitor=\ref[M]'>TP</A>\]</td>"
 		else

--- a/code/game/antagonist/antagonist_print.dm
+++ b/code/game/antagonist/antagonist_print.dm
@@ -12,7 +12,7 @@
 		if(ambition)
 			text += "<br>Their goals for today were..."
 			text += "<br>[SPAN_NOTICE("[ambition.summarize()]")]"
-		if(P.current?.stat == DEAD && P.last_words)
+		if(P.current?.is_real_dead() && P.last_words)
 			text += "<br><b>Their last words were:</b> '[P.last_words]'"
 		if(!length(global_objectives) && length(P.objectives))
 			var/num = 1
@@ -39,7 +39,7 @@
 	var/role = ply.assigned_role ? "\improper[ply.assigned_role]" : (ply.special_role ? "\improper[ply.special_role]" : "unknown role")
 	var/text = "<br><b>[ply.name]</b> [(ply.current?.get_preference_value(/datum/client_preference/show_ckey_credits) == GLOB.PREF_SHOW) ? "(<b>[ply.key]</b>)" : ""] as \a <b>[role]</b> ("
 	if(ply.current)
-		if(ply.current.stat == DEAD)
+		if(ply.current.is_real_dead())
 			text += "died"
 		else if(isNotStationLevel(ply.current.z))
 			text += "fled"

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1139,7 +1139,7 @@
 			to_chat(user, SPAN_NOTICE("You're too far away from [src] to do that."))
 		return USE_FAIL_NON_ADJACENT
 
-	if(!(use_flags & USE_ALLOW_DEAD) && user.stat == DEAD)
+	if(!(use_flags & USE_ALLOW_DEAD) && user.is_real_dead())
 		if (show_messages)
 			to_chat(user, SPAN_NOTICE("How do you expect to do that when you're dead?"))
 		return USE_FAIL_DEAD

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -116,7 +116,7 @@
 
 	var/mob/living/carbon/target = null
 	for(var/mob/living/carbon/M in get_turf(src))
-		if(!iscultist(M) && M.stat != DEAD)
+		if(!iscultist(M) && !M.is_dead())
 			target = M
 			break
 
@@ -339,7 +339,7 @@
 			soul = O
 			break
 	while(user)
-		if(user.stat == DEAD)
+		if(user.is_dead())
 			return
 		if(user.key)
 			return
@@ -442,7 +442,7 @@
 		return fizzle(user)
 	var/turf/T = get_turf(src)
 	for(var/mob/living/M in T)
-		if(M.stat != DEAD && !iscultist(M))
+		if(!M.is_dead() && !iscultist(M))
 			victim = M
 			break
 	if(!victim)
@@ -451,7 +451,7 @@
 	for(var/mob/living/M in cultists)
 		M.say("Barhah hra zar[pick("'","`")]garis!")
 
-	while(victim && victim.loc == T && victim.stat != DEAD)
+	while(victim && victim.loc == T && !victim.is_dead())
 		var/list/mob/living/casters = get_cultists()
 		if(length(casters) < 3)
 			break
@@ -464,7 +464,7 @@
 			if(H.is_asystole())
 				H.adjustBrainLoss(2 + length(casters))
 		sleep(40)
-	if(victim && victim.loc == T && victim.stat == DEAD)
+	if(victim && victim.loc == T && victim.is_dead())
 		GLOB.cult.add_cultiness(CULTINESS_PER_SACRIFICE)
 		var/obj/item/device/soulstone/full/F = new(get_turf(src))
 		for(var/mob/M in cultists | get_cultists())
@@ -720,7 +720,7 @@
 	var/obj/item/device/soulstone/source
 	var/datum/pronouns/pronouns = user.choose_from_pronouns()
 	for(var/mob/living/carbon/human/M in get_turf(src))
-		if(M.stat == DEAD)
+		if(M.is_real_dead())
 			if(iscultist(M))
 				if(M.key)
 					target = M

--- a/code/game/gamemodes/malfunction/newmalf_ability_trees/HARDWARE.dm
+++ b/code/game/gamemodes/malfunction/newmalf_ability_trees/HARDWARE.dm
@@ -126,7 +126,7 @@
 	var/timer = 300
 	while(timer)
 		sleep(10)
-		if(!user || !user.bombing_station || user.stat == DEAD)
+		if(!user || !user.bombing_station || user.is_dead())
 			radio.autosay("Self destruct sequence has been cancelled.", "Self-Destruct Control")
 			to_chat(user, "** Self destruct sequence has been cancelled **")
 			return

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -156,7 +156,7 @@
 			toggle_pump()
 			return TOPIC_REFRESH
 	if(href_list["chemical"] && href_list["amount"])
-		if(occupant && occupant.stat != DEAD)
+		if(occupant && !occupant.is_dead())
 			if(href_list["chemical"] in available_chemicals) // Your hacks are bad and you should feel bad
 				inject_chemical(user, href_list["chemical"], text2num(href_list["amount"]))
 				return TOPIC_REFRESH

--- a/code/game/machinery/camera/motion.dm
+++ b/code/game/machinery/camera/motion.dm
@@ -17,7 +17,7 @@
 			triggerAlarm()
 	else if (detectTime == -1)
 		for (var/mob/target in motionTargets)
-			if (target.stat == DEAD)
+			if (target.is_dead())
 				lostTarget(target)
 			// See if the camera is still in range
 			if(!in_range(src, target))

--- a/code/game/machinery/computer/ai_core.dm
+++ b/code/game/machinery/computer/ai_core.dm
@@ -230,7 +230,7 @@ var/global/list/empty_playable_ai_cores = list()
 		if (!new_brain)
 			USE_FEEDBACK_FAILURE("\The [tool] is empty and cannot be installed into \the [src].")
 			return TRUE
-		if (new_brain.stat == DEAD)
+		if (new_brain.is_dead())
 			USE_FEEDBACK_FAILURE("\The [tool] is dead and cannot be installed into \the [src].")
 			return TRUE
 		if (jobban_isbanned(brain, "AI"))

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -286,7 +286,7 @@
 	if(air_contents.total_moles < 10)
 		return
 	if(occupant)
-		if(occupant.stat == DEAD)
+		if(occupant.is_dead())
 			return
 		occupant.set_stat(UNCONSCIOUS)
 		var/has_cryo_medicine = occupant.reagents.has_any_reagent(list(/datum/reagent/cryoxadone, /datum/reagent/clonexadone, /datum/reagent/nanitefluid)) >= REM

--- a/code/game/machinery/teleporter/console.dm
+++ b/code/game/machinery/teleporter/console.dm
@@ -192,7 +192,7 @@
 			continue
 		var/mob/M = T.loc
 		var/turf/TT = get_turf(M)
-		if (M.stat == DEAD && world.time > M.timeofdeath + 15 MINUTES)
+		if (M.is_dead() && world.time > M.timeofdeath + 15 MINUTES)
 			continue
 		if (!isPlayerLevel(TT.z))
 			continue

--- a/code/game/machinery/vitals_monitor.dm
+++ b/code/game/machinery/vitals_monitor.dm
@@ -59,7 +59,7 @@
 		var/brain_activity = "none"
 		var/obj/item/organ/internal/brain/brain = victim.internal_organs_by_name[BP_BRAIN]
 		var/danger = FALSE
-		if (istype(brain) && victim.stat != DEAD && !GET_FLAGS(victim.status_flags, FAKEDEATH))
+		if (istype(brain) && !victim.is_dead())
 			if (user.skill_check(SKILL_MEDICAL, SKILL_BASIC))
 				switch (brain.get_current_damage_threshold())
 					if (0)
@@ -214,7 +214,7 @@
 	if (!victim)
 		return
 	var/obj/item/organ/internal/brain/brain = victim.internal_organs_by_name[BP_BRAIN]
-	if (istype(brain) && victim.stat != DEAD && !(victim.status_flags & FAKEDEATH))
+	if (istype(brain) && !victim.is_dead())
 		switch (brain.get_current_damage_threshold())
 			if (0 to 2)
 				AddOverlays(emissive_appearance(icon, "brain_ok"))

--- a/code/game/objects/auras/regenerating_aura.dm
+++ b/code/game/objects/auras/regenerating_aura.dm
@@ -29,7 +29,7 @@
 	var/mob/living/carbon/human/H = user
 	if(!istype(H))
 		CRASH("Someone gave [user.type] a [src.type] aura. This is invalid.")
-	if(!innate_heal || H.InStasis() || H.stat == DEAD)
+	if(!innate_heal || H.InStasis() || H.is_dead())
 		return FLAGS_OFF
 	if(H.nutrition < nutrition_damage_mult)
 		low_nut_warning()
@@ -137,7 +137,7 @@
 
 /obj/aura/regenerating/human/unathi/aura_check_life()
 	var/mob/living/carbon/human/H = user
-	if (!istype(H) || H.stat == DEAD)
+	if (!istype(H) || H.is_dead())
 		return AURA_CANCEL
 	if (H.stasis_value)
 		return AURA_FALSE

--- a/code/game/objects/items/devices/aicard.dm
+++ b/code/game/objects/items/devices/aicard.dm
@@ -23,7 +23,7 @@
 		data["backup_capacitor"] = carded_ai.backup_capacitor()
 		data["radio"] = !carded_ai.ai_radio.disabledAi
 		data["wireless"] = !carded_ai.control_disabled
-		data["operational"] = carded_ai.stat != DEAD
+		data["operational"] = !carded_ai.is_dead()
 		data["flushing"] = flush
 
 		var/laws[0]
@@ -53,7 +53,7 @@
 			admin_attack_log(user, carded_ai, "Wiped using \the [src.name]", "Was wiped with \the [src.name]", "used \the [src.name] to wipe")
 			flush = 1
 			to_chat(carded_ai, "Your core files are being wiped!")
-			while (carded_ai && carded_ai.stat != DEAD)
+			while (carded_ai && !carded_ai.is_real_dead())
 				carded_ai.adjustOxyLoss(2)
 				carded_ai.updatehealth()
 				sleep(10)

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -132,7 +132,7 @@
 
 	if(!BP_IS_ROBOTIC(vision))
 
-		if(vision.owner.stat == DEAD || H.blinded)	//mob is dead or fully blind
+		if(vision.owner.is_dead() || H.blinded)	//mob is dead or fully blind
 			to_chat(user, SPAN_WARNING("\The [H]'s pupils do not react to the light!"))
 			return
 		if(MUTATION_XRAY in H.mutations)

--- a/code/game/objects/items/devices/scanners/health.dm
+++ b/code/game/objects/items/devices/scanners/health.dm
@@ -84,7 +84,7 @@
 	var/brain_result = "normal"
 	if(H.should_have_organ(BP_BRAIN))
 		var/obj/item/organ/internal/brain/brain = H.internal_organs_by_name[BP_BRAIN]
-		if(!brain || H.stat == DEAD || (H.status_flags & FAKEDEATH))
+		if(!brain || H.is_dead())
 			brain_result = SPAN_CLASS("scan_danger", "none, patient is braindead")
 		else if(H.stat != DEAD)
 			if(H.has_brain_worms())
@@ -112,7 +112,7 @@
 		brain_result = SPAN_CLASS("scan_danger", "ERROR - Nonstandard biology")
 	dat += "Brain activity: [brain_result]."
 
-	if(H.stat == DEAD || (H.status_flags & FAKEDEATH))
+	if(H.is_dead())
 		dat += SPAN_CLASS("scan_warning", "[b]Time of Death:[endb] [time2text(worldtime2stationtime(H.timeofdeath), "hh:mm")]")
 
 	// Pulse rate.

--- a/code/game/objects/items/robot/robot_frame.dm
+++ b/code/game/objects/items/robot/robot_frame.dm
@@ -87,7 +87,7 @@
 			to_chat(user, SPAN_WARNING("\The [W] does not seem to fit."))
 			return TRUE
 
-		if(B.stat == DEAD)
+		if(B.is_dead())
 			to_chat(user, SPAN_WARNING("Sticking a dead [W.name] into the frame would sort of defeat the purpose."))
 			return TRUE
 

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -11,7 +11,7 @@
 	var/installed = 0
 
 /obj/item/borg/upgrade/proc/action(mob/living/silicon/robot/R)
-	if(R.stat == DEAD)
+	if(R.is_dead())
 		to_chat(usr, SPAN_WARNING("The [src] will not function on a deceased robot."))
 		return 1
 	return 0

--- a/code/game/objects/items/weapons/AI_modules.dm
+++ b/code/game/objects/items/weapons/AI_modules.dm
@@ -35,7 +35,7 @@ AI MODULES
 		to_chat(user, "You haven't selected an intelligence to transmit laws to!")
 		return
 
-	if(comp.current.stat == DEAD)
+	if(comp.current.is_dead())
 		to_chat(user, "Upload failed. No signal is being detected from the intelligence.")
 		return
 	if(istype(comp.current, /mob/living/silicon/ai))

--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -276,7 +276,7 @@
 		return "buzzes, \"Patient's chest is obstructed. Operation aborted.\""
 
 /obj/item/shockpaddles/proc/can_revive(mob/living/carbon/human/H) //This is checked right before attempting to revive
-	if(H.stat == DEAD)
+	if(H.is_dead())
 		return "buzzes, \"Resuscitation failed - Severe neurological decay makes recovery of patient impossible. Further attempts futile.\""
 
 /obj/item/shockpaddles/proc/check_contact(mob/living/carbon/human/H)

--- a/code/game/objects/items/weapons/implants/implants/death_alarm.dm
+++ b/code/game/objects/items/weapons/implants/implants/death_alarm.dm
@@ -26,7 +26,7 @@
 
 	if(isnull(M)) // If the mob got gibbed
 		activate(null)
-	else if(M.stat == DEAD)
+	else if(M.is_dead())
 		activate("death")
 
 /obj/item/implant/death_alarm/activate(cause = "emp")

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -336,7 +336,7 @@
 					C.adjustFireLoss(20)
 					C.adjustBrainLoss(5)
 
-					if(C.stat == DEAD || !(C in contents)) //In case we die or are removed at any point.
+					if(C.is_real_dead() || !(C in contents)) //In case we die or are removed at any point.
 						cremating = 0
 						update()
 						break
@@ -372,7 +372,7 @@
 									shake_animation()
 
 
-			if(M.stat == DEAD)
+			if(M.is_real_dead())
 				if(round_is_spooky())
 					if(prob(50))
 						playsound(src, 'sound/effects/ghost.ogg', 10, 5)

--- a/code/modules/ai/ai_holder_targeting.dm
+++ b/code/modules/ai/ai_holder_targeting.dm
@@ -126,7 +126,7 @@
 				return FALSE
 
 		if (L.stat)
-			if (L.stat == DEAD && !handle_corpse) // Leave dead things alone
+			if (L.is_dead() && !handle_corpse) // Leave dead things alone
 				return FALSE
 			if (L.stat == UNCONSCIOUS)	// Do we have mauling? Yes? Then maul people who are sleeping but not SSD
 				if (mauling)

--- a/code/modules/blob/blob.dm
+++ b/code/modules/blob/blob.dm
@@ -111,7 +111,7 @@
 	var/sound_played
 
 	for(var/mob/living/L in T)
-		if (L.stat == DEAD)
+		if (L.is_dead())
 			continue
 		if (!sound_played)
 			playsound(loc, 'sound/effects/attackblob.ogg', 50, 1)
@@ -162,7 +162,7 @@
 	var/attackDir = pick(dirs)
 	var/turf/T = get_step(src, attackDir)
 	for(var/mob/living/victim in T)
-		if(victim.stat == DEAD)
+		if(victim.is_dead())
 			continue
 		attack_living(victim)
 

--- a/code/modules/clothing/spacesuits/rig/modules/ninja.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/ninja.dm
@@ -235,7 +235,7 @@
 		return 0
 
 	//OH SHIT.
-	if(holder.wearer.stat == DEAD)
+	if(holder.wearer.is_dead())
 		if(active)
 			engage(null, TRUE)
 

--- a/code/modules/emotes/emote_mob.dm
+++ b/code/modules/emotes/emote_mob.dm
@@ -6,7 +6,7 @@
 
 /mob/proc/emote(act, m_type, message)
 	// s-s-snowflake
-	if((src.stat == DEAD || status_flags & FAKEDEATH) && act != "deathgasp")
+	if(is_dead() && act != "deathgasp")
 		return
 	if(usr == src) //client-called emote
 		if (client && (client.prefs.muted & MUTE_IC))

--- a/code/modules/integrated_electronics/subtypes/input.dm
+++ b/code/modules/integrated_electronics/subtypes/input.dm
@@ -147,7 +147,7 @@
 		return
 	if(H.Adjacent(get_turf(src))) // Like normal analysers, it can't be used at range.
 		var/obj/item/organ/internal/brain/brain = H.internal_organs_by_name[BP_BRAIN]
-		set_pin_data(IC_OUTPUT, 1, (brain && H.stat != DEAD))
+		set_pin_data(IC_OUTPUT, 1, (brain && !H.is_dead()))
 		set_pin_data(IC_OUTPUT, 2, H.get_pulse_as_number())
 		set_pin_data(IC_OUTPUT, 3, (H.stat == 0))
 
@@ -201,7 +201,7 @@
 
 
 		var/obj/item/organ/internal/brain/brain = H.internal_organs_by_name[BP_BRAIN]
-		set_pin_data(IC_OUTPUT, 1, (brain && H.stat != DEAD))
+		set_pin_data(IC_OUTPUT, 1, (brain && !H.is_dead()))
 		set_pin_data(IC_OUTPUT, 2, (H.stat == 0))
 		set_pin_data(IC_OUTPUT, 3, damage_to_severity(100 * H.getBruteLoss() / H.maxHealth))
 		set_pin_data(IC_OUTPUT, 4, damage_to_severity(100 * H.getFireLoss() / H.maxHealth))

--- a/code/modules/mob/death.dm
+++ b/code/modules/mob/death.dm
@@ -27,7 +27,7 @@
 /mob/proc/dust(anim="dust-m",remains=/obj/decal/cleanable/ash)
 	death(1)
 
-	if(stat == DEAD)
+	if(is_real_dead())
 		ghostize(FALSE) //Ghosts the mob here so it keeps its sprite
 
 	var/atom/movable/fake_overlay/animation = null

--- a/code/modules/mob/examinations.dm
+++ b/code/modules/mob/examinations.dm
@@ -15,7 +15,7 @@
 					to_chat(M, SPAN_SUBTLE("<b>\The [user]</b> looks at \the [A]."))
 	var/distance = INFINITY
 	var/is_adjacent = FALSE
-	if (isghost(user) || user.stat == DEAD)
+	if (isghost(user) || user.is_real_dead())
 		distance = 0
 		is_adjacent = TRUE
 	else

--- a/code/modules/mob/living/bot/medibot.dm
+++ b/code/modules/mob/living/bot/medibot.dm
@@ -56,7 +56,7 @@
 	if(busy)
 		return
 
-	if(H.stat == DEAD)
+	if(H.is_dead())
 		var/death_message = pick("No! NO!", "Live, damnit! LIVE!", "I... I've never lost a patient before. Not today, I mean.")
 		say(death_message)
 		target = null
@@ -249,7 +249,7 @@
 	if(!..())
 		return 0
 
-	if(H.stat == DEAD) // He's dead, Jim
+	if(H.is_dead()) // He's dead, Jim
 		return 0
 
 	if(emagged)

--- a/code/modules/mob/living/bot/secbot.dm
+++ b/code/modules/mob/living/bot/secbot.dm
@@ -196,7 +196,7 @@
 
 /mob/living/bot/secbot/lookForTargets()
 	for(var/mob/living/M in view(src))
-		if(M.stat == DEAD)
+		if(M.is_dead())
 			continue
 		if(confirmTarget(M))
 			var/threat = check_threat(M)
@@ -263,7 +263,7 @@
 	return "unidentified lifeform"
 
 /mob/living/bot/secbot/proc/check_threat(mob/living/M)
-	if(!M || !istype(M) || M.stat == DEAD || src == M)
+	if(!M || !istype(M) || M.is_dead() || src == M)
 		return 0
 
 	if(emagged && !M.incapacitated()) //check incapacitated so emagged secbots don't keep attacking the same target forever

--- a/code/modules/mob/living/carbon/alien/diona/nymph_life.dm
+++ b/code/modules/mob/living/carbon/alien/diona/nymph_life.dm
@@ -1,7 +1,7 @@
 //Dionaea regenerate health and nutrition in light.
 /mob/living/carbon/alien/diona/handle_environment(datum/gas_mixture/environment)
 	..()
-	if(health <= 0 || stat == DEAD)
+	if(health <= 0 || is_real_dead())
 		return
 
 	var/turf/checking = get_turf(src)

--- a/code/modules/mob/living/carbon/alien/diona/nymph_update_icons.dm
+++ b/code/modules/mob/living/carbon/alien/diona/nymph_update_icons.dm
@@ -1,6 +1,6 @@
 /mob/living/carbon/alien/diona/update_icons()
 	var/list/adding = list()
-	if(stat == DEAD)
+	if(is_dead())
 		icon_state = "[initial(icon_state)]_dead"
 	else if(lying || resting || stunned)
 		icon_state = "[initial(icon_state)]_sleep"

--- a/code/modules/mob/living/carbon/allergy.dm
+++ b/code/modules/mob/living/carbon/allergy.dm
@@ -72,7 +72,7 @@ Also checks if medications that stop allergies from triggering are in system. Th
 	return
 
 /mob/living/carbon/handle_allergy()
-	if (stat == DEAD)
+	if (is_dead())
 		return
 	if (!HAS_TRAIT(src, /singleton/trait/malus/allergy))
 		return

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -173,7 +173,7 @@
 
 	if (src.stat)
 		msg += "[SPAN_WARNING("[P.He] [P.is]n't responding to anything around [P.him] and seems to be unconscious.")]\n"
-		if((stat == DEAD || is_asystole() || losebreath || status_flags & FAKEDEATH) && distance <= 3)
+		if((is_dead() || is_asystole() || losebreath) && distance <= 3)
 			msg += "[SPAN_DANGER("[P.He] [P.does] not appear to be breathing.")]\n"
 
 	if (fire_stacks > 0)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -748,7 +748,7 @@
 /mob/living/carbon/human/vomit(timevomit = 1, level = 3, delay = 0)
 	set waitfor = 0
 
-	if(!check_has_mouth() || isSynthetic() || !timevomit || !level || stat == DEAD || lastpuke)
+	if(!check_has_mouth() || isSynthetic() || !timevomit || !level || is_dead() || lastpuke)
 		return
 
 	timevomit = clamp(timevomit, 1, 10)
@@ -1679,7 +1679,7 @@
 // output for machines ^	 ^ ^ ^ ^ ^ ^ ^ ^ ^ ^ output for people
 
 /mob/living/carbon/human/proc/pulse()
-	if (stat == DEAD)
+	if (is_real_dead())
 		return PULSE_NONE
 	var/obj/item/organ/internal/heart/H = internal_organs_by_name[BP_HEART]
 	return H ? H.pulse : PULSE_NONE

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -9,7 +9,7 @@
 	health = maxHealth - getBrainLoss()
 
 	//TODO: fix husking
-	if(((maxHealth - getFireLoss()) < config.health_threshold_dead) && stat == DEAD)
+	if(((maxHealth - getFireLoss()) < config.health_threshold_dead) && is_real_dead())
 		ChangeToHusk()
 	return
 

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -243,7 +243,7 @@
 	to_chat(src, SPAN_NOTICE("You take a moment to listen in to your environment..."))
 	for(var/mob/living/L in range(client.view, src))
 		var/turf/T = get_turf(L)
-		if(!T || L == src || L.stat == DEAD || is_below_sound_pressure(T))
+		if(!T || L == src || L.is_dead() || is_below_sound_pressure(T))
 			continue
 		heard_something = TRUE
 		var/image/ping_image = image(icon = 'icons/effects/effects.dmi', icon_state = "sonar_ping", loc = src)

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -979,7 +979,7 @@
 				break
 
 //SIERRA-ADD
-		if(stat == DEAD || status_flags & FAKEDEATH)
+		if(is_dead())
 			holder.icon_state = "0" 	// X_X
 		else if(is_asystole())
 			holder.icon_state = "flatline"
@@ -989,7 +989,7 @@
 
 	if (GET_BIT(hud_updateflag, LIFE_HUD) && hud_list[LIFE_HUD])
 		var/image/holder = hud_list[LIFE_HUD]
-		if(stat == DEAD || status_flags & FAKEDEATH)
+		if(is_dead())
 			holder.icon_state = "huddead"
 //SIERRA-ADD VIRUSOLOGY
 		else if(foundVirus)
@@ -1014,7 +1014,7 @@
 			holder.icon_state = "hudhealthy"
 
 		var/image/holder2 = hud_list[STATUS_HUD_OOC]
-		if(stat == DEAD)
+		if(is_real_dead())
 			holder2.icon_state = "huddead"
 		else if(has_brain_worms())
 			holder2.icon_state = "hudbrainworm"

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -155,7 +155,6 @@ Please contact me on #coderbus IRC. ~Carn x
 #define HO_FIRE_LAYER       28 //If you're on fire
 #define HO_EFFECTS_LAYER    29
 #define TOTAL_LAYERS        30
-
 //////////////////////////////////
 
 /mob/living/carbon/human
@@ -750,7 +749,7 @@ var/global/list/damage_icon_parts = list()
 		queue_icon_update()
 
 /mob/living/carbon/human/proc/animate_tail_reset(update_icons=1)
-	if(stat != DEAD)
+	if(!is_dead())
 		set_tail_state("[species.get_tail(src)]_idle[rand(0,9)]")
 	else
 		set_tail_state("[species.get_tail(src)]_static")

--- a/code/modules/mob/living/carbon/xenobiological/examine.dm
+++ b/code/modules/mob/living/carbon/xenobiological/examine.dm
@@ -1,7 +1,7 @@
 /mob/living/carbon/slime/examine(mob/user)
 	. = ..()
 	var/msg = ""
-	if (src.stat == DEAD)
+	if (is_dead())
 		msg += "[SPAN_CLASS("deadsay", "It is limp and unresponsive.")]\n"
 	else
 		if (src.getBruteLoss())

--- a/code/modules/mob/living/carbon/xenobiological/powers.dm
+++ b/code/modules/mob/living/carbon/xenobiological/powers.dm
@@ -18,7 +18,7 @@
 /mob/living/carbon/slime/proc/invalidFeedTarget(mob/living/living)
 	if (!istype(living))
 		return "This subject is incompatible..."
-	if (living.stat == DEAD)
+	if (living.is_dead())
 		return "This subject is dead..."
 	if (!Adjacent(living))
 		return "This subject is too far away..."

--- a/code/modules/mob/living/carbon/xenobiological/slime_AI.dm
+++ b/code/modules/mob/living/carbon/xenobiological/slime_AI.dm
@@ -95,7 +95,7 @@
 	if(M in Friends) // Ignore friends
 		return 0
 
-	if(M.stat != DEAD) // Checks for those we just want to attack
+	if(!M.is_dead()) // Checks for those we just want to attack
 		if(rabid || attacked) // Will attack everything that isn't dead
 			return 1
 

--- a/code/modules/mob/living/carbon/xenobiological/update_icons.dm
+++ b/code/modules/mob/living/carbon/xenobiological/update_icons.dm
@@ -1,5 +1,5 @@
 /mob/living/carbon/slime/regenerate_icons()
-	if (stat == DEAD)
+	if (is_dead())
 		icon_state = "[colour] baby slime dead"
 	else
 		icon_state = "[colour] [is_adult ? "adult" : "baby"] slime[Victim ? "" : " eat"]"

--- a/code/modules/mob/living/living_health.dm
+++ b/code/modules/mob/living/living_health.dm
@@ -17,7 +17,7 @@
 
 
 /mob/living/health_dead()
-	if (stat == DEAD)
+	if (is_real_dead())
 		return TRUE
 	return ..()
 

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -465,7 +465,7 @@ var/global/list/ai_verbs_default = list(
 
 
 /mob/living/silicon/ai/proc/switchCamera(obj/machinery/camera/C)
-	if (!C || stat == DEAD) //C.can_use())
+	if (!C || is_dead()) //C.can_use())
 		return 0
 
 	if(!src.eyeobj)
@@ -676,7 +676,7 @@ var/global/list/ai_verbs_default = list(
 	to_chat(usr, SPAN_INFO("Your hologram will now [hologram_follow ? "follow" : "no longer follow"] you."))
 
 /mob/living/silicon/ai/proc/check_unable(flags = 0, feedback = 1)
-	if(stat == DEAD)
+	if(is_dead())
 		if(feedback) to_chat(src, SPAN_WARNING("You are dead!"))
 		return 1
 
@@ -718,7 +718,7 @@ var/global/list/ai_verbs_default = list(
 		selected_sprite = new default_ai_icon()
 
 	icon = selected_sprite.icon
-	if(stat == DEAD)
+	if(is_dead())
 		icon_state = selected_sprite.dead_icon
 		set_light(1, 0.7, selected_sprite.dead_light)
 	else if(!has_power())

--- a/code/modules/mob/living/silicon/ai/examine.dm
+++ b/code/modules/mob/living/silicon/ai/examine.dm
@@ -2,7 +2,7 @@
 	. = ..()
 
 	var/msg = ""
-	if (src.stat == DEAD)
+	if (is_dead())
 		msg += "[SPAN_CLASS("deadsay", "It appears to be powered-down.")]\n"
 	else
 		var/damage_msg = ""

--- a/code/modules/mob/living/silicon/ai/power.dm
+++ b/code/modules/mob/living/silicon/ai/power.dm
@@ -211,7 +211,7 @@
 
 /obj/machinery/ai_powersupply/proc/get_power_state()
 	// Dead, powered by APU, admin power, or inside an item (inteliCard/IIS). No power usage.
-	if(!powered_ai.stat == DEAD || powered_ai.APU_power || powered_ai.admin_powered || istype(powered_ai.loc, /obj/item))
+	if(!powered_ai.is_real_dead() || powered_ai.APU_power || powered_ai.admin_powered || istype(powered_ai.loc, /obj/item))
 		return 0
 	// Normal power usage.
 	return 2

--- a/code/modules/mob/living/silicon/robot/analyzer.dm
+++ b/code/modules/mob/living/silicon/robot/analyzer.dm
@@ -47,7 +47,7 @@
 			user.show_message(SPAN_NOTICE("Analyzing Results for [M]:\n\t Overall Status: [M.stat > 1 ? "fully disabled" : "[M.health - M.getHalLoss()]% functional"]"))
 			user.show_message("\t Key: [SPAN_COLOR("#ffa500", "Electronics")]/[SPAN_COLOR("red", "Brute")]", 1)
 			user.show_message("\t Damage Specifics: [SPAN_COLOR("#ffa500", BU)] - [SPAN_COLOR("red", BR)]")
-			if(M.stat == DEAD)
+			if(M.is_dead())
 				user.show_message(SPAN_NOTICE("Time of Failure: [time2text(worldtime2stationtime(M.timeofdeath))]"))
 			var/mob/living/silicon/robot/H = M
 			var/list/damaged = H.get_damaged_components(1,1,1)

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -219,7 +219,7 @@ var/global/list/mob_hat_cache = list()
 	if (istype(id))
 		var/id_name = GET_ID_NAME(id, tool)
 		// Reboot
-		if (stat == DEAD)
+		if (is_dead())
 			if (!config.allow_drone_spawn || emagged || health < -35)
 				USE_FEEDBACK_FAILURE("\The [src] interface is fried, and a distressing burned smell wafts from \his interior. You're not rebooting this one.")
 				return TRUE

--- a/code/modules/mob/living/silicon/robot/drone/drone_say.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_say.dm
@@ -7,7 +7,7 @@
 
 		message = sanitize(message)
 
-		if (stat == DEAD)
+		if (is_real_dead())
 			return say_dead(message)
 
 		if(copytext_char(message,1,2) == get_prefix_key(/singleton/prefix/custom_emote))
@@ -32,7 +32,7 @@
 		for (var/mob/M in GLOB.player_list)
 			if (istype(M, /mob/new_player))
 				continue
-			else if(M.stat == DEAD && M.get_preference_value(/datum/client_preference/ghost_ears) == GLOB.PREF_ALL_SPEECH)
+			else if(M.is_real_dead() && M.get_preference_value(/datum/client_preference/ghost_ears) == GLOB.PREF_ALL_SPEECH)
 				if(M.client) to_chat(M, "<b>[src]</b> transmits, \"[message]\"")
 		return 1
 	return ..(message, 0)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -381,7 +381,7 @@
 	set category = "Silicon Commands"
 	set name = "Toggle Lights"
 
-	if(stat == DEAD)
+	if(is_dead())
 		return
 
 	lights_on = !lights_on

--- a/code/modules/mob/living/simple_animal/borer/borer_captive.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer_captive.dm
@@ -33,7 +33,7 @@
 		for (var/mob/M in GLOB.player_list)
 			if (istype(M, /mob/new_player))
 				continue
-			else if(M.stat == DEAD && M.get_preference_value(/datum/client_preference/ghost_ears) == GLOB.PREF_ALL_SPEECH)
+			else if(M.is_real_dead() && M.get_preference_value(/datum/client_preference/ghost_ears) == GLOB.PREF_ALL_SPEECH)
 				to_chat(M, "The captive mind of [src] whispers, \"[message]\"")
 
 /mob/living/captive_brain/process_resist()

--- a/code/modules/mob/living/simple_animal/borer/borer_hud.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer_hud.dm
@@ -18,7 +18,7 @@
 /obj/screen/borer/Click(location, control, params)
 	if(!istype(usr, /mob/living/simple_animal/borer))
 		return FALSE
-	if(usr.stat == DEAD)
+	if(usr.is_dead())
 		return FALSE
 	var/mob/living/simple_animal/borer/worm = usr
 	if(!worm.host)

--- a/code/modules/mob/living/simple_animal/borer/borer_powers.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer_powers.dm
@@ -41,7 +41,7 @@
 
 	H.add_language(LANGUAGE_BORER_GLOBAL)
 
-	if(host.stat == DEAD)
+	if(host.is_dead())
 		H.verbs |= /mob/living/carbon/human/proc/jumpstart
 
 	H.verbs |= /mob/living/carbon/human/proc/psychic_whisper

--- a/code/modules/mob/living/simple_animal/constructs/soulstone.dm
+++ b/code/modules/mob/living/simple_animal/constructs/soulstone.dm
@@ -117,7 +117,7 @@
 	if (full == SOULSTONE_ESSENCE)
 		to_chat(user, SPAN_NOTICE("\The [src] is already full."))
 		return TRUE
-	if (M.stat != DEAD && !M.is_asystole())
+	if (!M.is_real_dead() && !M.is_asystole())
 		to_chat(user, SPAN_NOTICE("Kill or maim the victim first."))
 		return TRUE
 	for (var/obj/item/W in M)

--- a/code/modules/mob/living/simple_animal/defense.dm
+++ b/code/modules/mob/living/simple_animal/defense.dm
@@ -61,7 +61,7 @@
 /mob/living/simple_animal/use_tool(obj/item/tool, mob/user, list/click_params)
 	// Butcher's Cleaver - Butcher dead mob
 	if (istype(tool, /obj/item/material/knife/kitchen/cleaver))
-		if (stat != DEAD)
+		if (!is_dead())
 			USE_FEEDBACK_FAILURE("\The [src] must be dead before you can butcher \him.")
 			return TRUE
 		if (!meat_type || !meat_amount)
@@ -96,7 +96,7 @@
 
 	// Medical - Attempt healing
 	if (istype(tool, /obj/item/stack/medical))
-		if (stat == DEAD)
+		if (is_dead())
 			USE_FEEDBACK_FAILURE("\The [src] is dead, medical items won't bring \him back to life.")
 			return TRUE
 		if (health >= maxHealth)

--- a/code/modules/mob/living/simple_animal/friendly/juvenile_space_whale.dm
+++ b/code/modules/mob/living/simple_animal/friendly/juvenile_space_whale.dm
@@ -50,7 +50,7 @@
 	. = ..()
 	if(!.)
 		return FALSE
-	if(parent && parent.stat != DEAD)
+	if(parent && !parent.is_dead())
 		if(parent.stance == STANCE_IDLE && (pulledby || length(grabbed_by)))
 			var/enemies = pulledby ? list(pulledby) : grabbed_by
 			parent.ai_holder.attackers += enemies

--- a/code/modules/mob/living/simple_animal/friendly/possum.dm
+++ b/code/modules/mob/living/simple_animal/friendly/possum.dm
@@ -75,7 +75,7 @@
 
 /mob/living/simple_animal/passive/opossum/on_update_icon()
 
-	if(stat == DEAD || (resting && is_angry))
+	if(is_dead() || (resting && is_angry))
 		icon_state = icon_dead
 	else if(resting || stat == UNCONSCIOUS)
 		icon_state = "[icon_living]_sleep"

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/drone.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/drone.dm
@@ -217,7 +217,7 @@
 		return ..()
 	var/list/targets = list()
 	for (var/mob/living/M in oview(D.hostile_range, D))
-		if (M.stat == DEAD)
+		if (M.is_dead())
 			continue
 		if (M.type == D.type)
 			continue

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/exoplanet.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/exoplanet.dm
@@ -13,7 +13,7 @@
 		ai_holder.hostile = FALSE
 	else
 		for(var/mob/living/simple_animal/S in range(src,1))
-			if(S.stat == DEAD && S != src)
+			if(S.is_dead() && S != src)
 				visible_message("[src] consumes \the body of [S]!")
 				var/turf/T = get_turf(S)
 				var/obj/item/remains/xeno/X = new(T)

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/goose.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/goose.dm
@@ -48,7 +48,7 @@
 	canremove = FALSE
 
 /mob/living/simple_animal/hostile/retaliate/goose/on_update_icon()
-	if(stat == DEAD)
+	if(is_dead())
 		icon_state = icon_dead
 	else if(loose)
 		icon_state = "goose_loose"

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -235,7 +235,7 @@
 /mob/living/simple_animal/proc/harvest(mob/user, skill_level)
 	var/actual_meat_amount = round(max(1,(meat_amount / 2) + skill_level / 2))
 	user.visible_message(SPAN_DANGER("\The [user] chops up \the [src]!"))
-	if(meat_type && actual_meat_amount > 0 && (stat == DEAD))
+	if(meat_type && actual_meat_amount > 0 && (is_dead()))
 		for(var/i=0;i<actual_meat_amount;i++)
 			var/obj/item/meat = new meat_type(get_turf(src))
 			meat.SetName("[src.name] [meat.name]")

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -637,7 +637,14 @@
 /mob/proc/is_active()
 	return (0 >= usr.stat)
 
+/// Checks if a mob should be considered dead. Includes faked deaths and other situational conditions.
 /mob/proc/is_dead()
+	if (GET_FLAGS(status_flags, FAKEDEATH))
+		return TRUE
+	return is_real_dead()
+
+/// Checks if a mob is actually dead. Ignores faked deaths.
+/mob/proc/is_real_dead()
 	return stat == DEAD
 
 /mob/proc/is_mechanical()

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -478,7 +478,7 @@ var/global/list/intents = list(I_HELP,I_DISARM,I_GRAB,I_HURT)
 
 #define SAFE_PERP -50
 /mob/living/proc/assess_perp(obj/access_obj, check_access, auth_weapons, check_records, check_arrest)
-	if(stat == DEAD)
+	if(is_dead())
 		return SAFE_PERP
 
 	return 0

--- a/code/modules/mob/observer/freelook/ai/chunk.dm
+++ b/code/modules/mob/observer/freelook/ai/chunk.dm
@@ -14,7 +14,7 @@
 				visible[t] = t
 		else if(isAI(source))
 			var/mob/living/silicon/ai/AI = source
-			if(AI.stat == DEAD)
+			if(AI.is_dead())
 				continue
 			for(var/turf/t in seen_turfs_in_range(AI, world.view))
 				visible[t] = t

--- a/code/modules/mob/observer/freelook/cult/cultnet.dm
+++ b/code/modules/mob/observer/freelook/cult/cultnet.dm
@@ -6,7 +6,7 @@
 	for(var/source in sources)
 		if(istype(source, /mob/living))
 			var/mob/living/L = source
-			if(L.stat == DEAD)
+			if(L.is_dead())
 				continue
 
 		for(var/turf/t in seen_turfs_in_range(source, world.view))

--- a/code/modules/modular_computers/file_system/programs/research/ai_restorer.dm
+++ b/code/modules/modular_computers/file_system/programs/research/ai_restorer.dm
@@ -72,7 +72,7 @@
 	A.adjustOxyLoss(-4)
 	A.updatehealth()
 	// If the AI is dead, revive it.
-	if (A.health >= -100 && A.stat == DEAD)
+	if (A.health >= -100 && A.is_real_dead())
 		A.set_stat(CONSCIOUS)
 		A.lying = 0
 		A.switch_from_dead_to_living_mob_list()
@@ -110,7 +110,7 @@
 		data["ai_integrity"] = A.hardware_integrity()
 		data["ai_capacitor"] = A.backup_capacitor()
 		data["ai_isdamaged"] = (A.hardware_integrity() < 100) || (A.backup_capacitor() < 100)
-		data["ai_isdead"] = (A.stat == DEAD)
+		data["ai_isdead"] = (A.is_dead())
 
 		var/list/all_laws[0]
 		for(var/datum/ai_law/L in A.laws.all_laws())

--- a/code/modules/organs/internal/brain.dm
+++ b/code/modules/organs/internal/brain.dm
@@ -135,11 +135,11 @@
 	healed_threshold = 0
 	to_chat(owner, SPAN_NOTICE(FONT_GIANT("<B>What's going on...?</B>")))
 	sleep(5 SECONDS)
-	if (!owner || owner.stat == DEAD || (status & ORGAN_DEAD))
+	if (!owner || owner.is_real_dead() || (status & ORGAN_DEAD))
 		return
 	to_chat(owner, SPAN_NOTICE(FONT_GIANT("<B>What's going on...?</B>")))
 	sleep(10 SECONDS)
-	if (!owner || owner.stat == DEAD || (status & ORGAN_DEAD))
+	if (!owner || owner.is_real_dead() || (status & ORGAN_DEAD))
 		return
 	to_chat(owner, SPAN_NOTICE(FONT_GIANT("<B>What happened...?</B>")))
 	alert(owner, "You have taken massive brain damage! You will not be able to remember the events leading up to your injury.", "Brain Damaged")
@@ -231,7 +231,7 @@
 //SIERRA				addtimer(CALLBACK(src, .proc/brain_damage_callback, damage), rand(6, 20) SECONDS, TIMER_UNIQUE)
 
 /obj/item/organ/internal/brain/proc/brain_damage_callback(damage) //Confuse them as a somewhat uncommon aftershock. Side note: Only here so a spawn isn't used. Also, for the sake of a unique timer.
-	if (!owner || owner.stat == DEAD || (status & ORGAN_DEAD))
+	if (!owner || owner.is_real_dead() || (status & ORGAN_DEAD))
 		return
 
 	to_chat(owner, SPAN_NOTICE(SPAN_STYLE("font-size: 10", "<B>I can't remember which way is forward...</B>")))

--- a/code/modules/organs/internal/heart.dm
+++ b/code/modules/organs/internal/heart.dm
@@ -125,7 +125,7 @@
 		return
 
 	//Dead or cryosleep people do not pump the blood.
-	if(!owner || owner.InStasis() || owner.stat == DEAD || owner.bodytemperature < 170)
+	if(!owner || owner.InStasis() || owner.is_real_dead() || owner.bodytemperature < 170)
 		return
 
 	if(pulse != PULSE_NONE || BP_IS_ROBOTIC(src))

--- a/code/modules/organs/internal/species/fbp.dm
+++ b/code/modules/organs/internal/species/fbp.dm
@@ -48,7 +48,7 @@
 	..()
 	if(!owner)
 		return
-	if(owner.stat == DEAD)	//not a drain anymore
+	if(owner.is_real_dead())	//not a drain anymore
 		return
 	var/cost = get_power_drain()
 	if(world.time - owner.l_move_time < 15)
@@ -97,7 +97,7 @@
 /obj/item/organ/internal/cell/replaced()
 	..()
 	// This is very ghetto way of rebooting an IPC. TODO better way.
-	if(owner && owner.stat == DEAD)
+	if(owner && owner.is_real_dead())
 		owner.set_stat(CONSCIOUS)
 		owner.visible_message(SPAN_DANGER("\The [owner] twitches visibly!"))
 
@@ -165,7 +165,7 @@
 	stored_mmi.update_icon()
 	icon_state = stored_mmi.icon_state
 
-	if(owner && owner.stat == DEAD)
+	if(owner && owner.is_real_dead())
 		owner.set_stat(CONSCIOUS)
 		owner.switch_from_dead_to_living_mob_list()
 		owner.visible_message(SPAN_DANGER("\The [owner] twitches visibly!"))

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -1204,7 +1204,7 @@
 
 // Malfunction: Transfers APC under AI's control
 /obj/machinery/power/apc/proc/ai_hack(mob/living/silicon/ai/A = null)
-	if(!A || !A.hacked_apcs || hacker || aidisabled || A.stat == DEAD)
+	if(!A || !A.hacked_apcs || hacker || aidisabled || A.is_dead())
 		return 0
 	src.hacker = A
 	A.hacked_apcs += src

--- a/code/modules/psionics/faculties/coercion.dm
+++ b/code/modules/psionics/faculties/coercion.dm
@@ -66,7 +66,7 @@
 	if(!.)
 		return
 
-	if(target.stat == DEAD || (target.status_flags & FAKEDEATH) || !target.client)
+	if(target.is_dead() || !target.client)
 		to_chat(user, SPAN_WARNING("\The [target] is in no state for a mind-ream."))
 		return TRUE
 
@@ -80,7 +80,7 @@
 	to_chat(target, SPAN_NOTICE("<b>Your mind is compelled to answer: <i>[question]</i></b>"))
 
 	var/answer =  input(target, question, "Read Mind") as null|text
-	if(!answer || world.time > started_mindread + 60 SECONDS || user.stat != CONSCIOUS || target.stat == DEAD)
+	if(!answer || world.time > started_mindread + 60 SECONDS || user.stat != CONSCIOUS || target.is_dead())
 		to_chat(user, SPAN_NOTICE("<b>You receive nothing useful from \the [target].</b>"))
 	else
 		to_chat(user, SPAN_NOTICE("<b>You skim thoughts from the surface of \the [target]'s mind: <i>[answer]</i></b>"))
@@ -148,7 +148,7 @@
 		return FALSE
 	. = ..()
 	if(.)
-		if(target.stat == DEAD || (target.status_flags & FAKEDEATH))
+		if(target.is_dead())
 			to_chat(user, SPAN_WARNING("\The [target] is dead!"))
 			return TRUE
 		if(!target.mind || !target.key)

--- a/code/modules/psionics/faculties/redaction.dm
+++ b/code/modules/psionics/faculties/redaction.dm
@@ -11,7 +11,7 @@
 /singleton/psionic_power/redaction/proc/check_dead(mob/living/target)
 	if(!istype(target))
 		return FALSE
-	if(target.stat == DEAD || (target.status_flags & FAKEDEATH))
+	if(target.is_dead())
 		return TRUE
 	return FALSE
 
@@ -166,7 +166,7 @@
 		return FALSE
 	. = ..()
 	if(.)
-		if(target.stat != DEAD && !(target.status_flags & FAKEDEATH))
+		if(!target.is_dead())
 			to_chat(user, SPAN_WARNING("This person is already alive!"))
 			return TRUE
 

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -105,7 +105,7 @@
 		return // Something else removed us.
 	if(!istype(M))
 		return
-	if(!(flags & AFFECTS_DEAD) && M.stat == DEAD && (world.time - M.timeofdeath > 150))
+	if(!(flags & AFFECTS_DEAD) && M.is_dead() && (world.time - M.timeofdeath > 150))
 		return
 	if(overdose && (location != CHEM_TOUCH))
 		var/overdose_threshold = overdose * (flags & IGNORE_MOB_SIZE? 1 : MOB_MEDIUM/M.mob_size)

--- a/code/modules/species/outsider/shadow.dm
+++ b/code/modules/species/outsider/shadow.dm
@@ -24,7 +24,7 @@
 	species_flags = SPECIES_FLAG_NO_SCAN | SPECIES_FLAG_NO_SLIP | SPECIES_FLAG_NO_POISON | SPECIES_FLAG_NO_EMBED
 
 /singleton/species/starlight/shadow/handle_environment_special(mob/living/carbon/human/H)
-	if(H.InStasis() || H.stat == DEAD || H.isSynthetic())
+	if(H.InStasis() || H.is_dead() || H.isSynthetic())
 		return
 	var/light_amount = 0
 	if(isturf(H.loc))

--- a/code/modules/species/outsider/zombie.dm
+++ b/code/modules/species/outsider/zombie.dm
@@ -512,7 +512,7 @@ GLOBAL_LIST_AS(zombie_species, list(\
 	var/mob/living/carbon/human/target
 	var/list/victims = list()
 	for (var/mob/living/carbon/human/L in get_turf(src))
-		if (L != src && (L.lying || L.stat == DEAD))
+		if (L != src && (L.lying || L.is_dead()))
 			if (L.is_zombie())
 				to_chat(src, SPAN_WARNING("\The [L] isn't fresh anymore!"))
 				continue
@@ -536,7 +536,7 @@ GLOBAL_LIST_AS(zombie_species, list(\
 	if (!target)
 		to_chat(src, SPAN_WARNING("You aren't on top of a victim!"))
 		return
-	if (get_turf(src) != get_turf(target) || !(target.lying || target.stat == DEAD))
+	if (get_turf(src) != get_turf(target) || !(target.lying || target.is_dead()))
 		to_chat(src, SPAN_WARNING("You're no longer on top of \the [target]!"))
 		return
 
@@ -550,13 +550,13 @@ GLOBAL_LIST_AS(zombie_species, list(\
 	if (do_after(src, 5 SECONDS, target, DO_DEFAULT | DO_USER_UNIQUE_ACT, INCAPACITATION_KNOCKOUT))
 		admin_attack_log(src, target, "Consumed their victim.", "Was consumed.", "consumed")
 
-		if (!target.lying && target.stat != DEAD) //Check victims are still prone
+		if (!target.lying && !target.is_dead()) //Check victims are still prone
 			return
 
 		target.reagents.add_reagent(/datum/reagent/zombie, 35) //Just in case they haven't been infected already
 		if (target.getBruteLoss() > target.maxHealth * 1.5)
 			to_chat(src,SPAN_WARNING("You've scraped \the [target] down to the bones already!."))
-			if (target.stat != DEAD)
+			if (!target.is_real_dead())
 				target.zombify()
 			else if (!(MUTATION_SKELETON in target.mutations))
 				if (istype(target, /mob/living/carbon/human/monkey))

--- a/code/modules/spells/aoe_turf/drain_blood.dm
+++ b/code/modules/spells/aoe_turf/drain_blood.dm
@@ -17,7 +17,7 @@
 /spell/aoe_turf/drain_blood/cast(list/targets, mob/user)
 	for(var/t in targets)
 		for(var/mob/living/L in t)
-			if(L.stat == DEAD || L == user)
+			if(L.is_dead() || L == user)
 				continue
 			//Hurt target
 			if(istype(L, /mob/living/carbon/human))

--- a/code/modules/spells/targeted/shapeshift.dm
+++ b/code/modules/spells/targeted/shapeshift.dm
@@ -24,7 +24,7 @@
 /spell/targeted/shapeshift/cast(list/targets, mob/user)
 	for(var/m in targets)
 		var/mob/living/M = m
-		if(M.stat == DEAD)
+		if(M.is_dead())
 			to_chat(user, "[name] can only transform living targets.")
 			continue
 		if(M.buckled)

--- a/code/modules/surgery/generic.dm
+++ b/code/modules/surgery/generic.dm
@@ -153,7 +153,7 @@
 	. = ..()
 	if(user.skill_check(SKILL_FORENSICS, SKILL_TRAINED))
 		. += 40
-		if(target.stat == DEAD)
+		if(target.is_dead())
 			. += 40
 
 //////////////////////////////////////////////////////////////////

--- a/code/modules/surgery/slimes.dm
+++ b/code/modules/surgery/slimes.dm
@@ -15,7 +15,7 @@
 	return TRUE
 
 /singleton/surgery_step/slime/assess_surgery_candidate(mob/living/user, mob/living/carbon/slime/target, target_zone, obj/item/tool)
-	return isslime(target) && target.stat == DEAD
+	return isslime(target) && target.is_dead()
 
 /singleton/surgery_step/slime/get_skill_reqs(mob/living/user, mob/living/carbon/human/target, obj/item/tool)
 	return list(SKILL_SCIENCE = SKILL_TRAINED)

--- a/maps/torch/torch_simplemobs.dm
+++ b/maps/torch/torch_simplemobs.dm
@@ -196,7 +196,7 @@
 
 /mob/living/simple_animal/hostile/human/fleet/space/ranged/on_update_icon()
 	..()
-	if(stat != DEAD)
+	if(!is_dead())
 		if(deactivated)
 			AddOverlays(image(icon, "disabled"))
 			return
@@ -285,7 +285,7 @@
 
 /mob/living/simple_animal/hostile/human/fleet/space/ranged/heavy/on_update_icon()
 	..()
-	if(stat != DEAD)
+	if(!is_dead())
 		if(deactivated)
 			AddOverlays(image(icon, "disabled"))
 			return

--- a/mods/ai/code/boris.dm
+++ b/mods/ai/code/boris.dm
@@ -40,7 +40,7 @@ GLOBAL_LIST_EMPTY(available_ai_shells)
 			var/obj/item/organ/internal/posibrain/P = W
 			B = P.brainmob
 
-		if(B.stat == DEAD)
+		if(B.is_dead())
 			to_chat(user, SPAN_WARNING("Sticking a dead [W.name] into the frame would sort of defeat the purpose."))
 			return TRUE
 

--- a/mods/psionics/code/faculties/coercion.dm
+++ b/mods/psionics/code/faculties/coercion.dm
@@ -197,7 +197,7 @@
 		return FALSE
 	. = ..()
 	if(.)
-		if(target.stat == DEAD || (target.status_flags & FAKEDEATH))
+		if(target.is_dead())
 			to_chat(user, SPAN_WARNING("\The [target] мертв!"))
 			return TRUE
 		if(!target.mind || !target.key)

--- a/mods/psionics/code/faculties/consciousness.dm
+++ b/mods/psionics/code/faculties/consciousness.dm
@@ -62,7 +62,7 @@
 		return FALSE
 	. = ..()
 	if(.)
-		if(target.stat == DEAD || (target.status_flags & FAKEDEATH) || !target.client)
+		if(target.is_dead() || !target.client)
 			to_chat(user, SPAN_WARNING("[target] не в состоянии ответить вам."))
 			return FALSE
 
@@ -170,7 +170,7 @@
 			to_chat(user, SPAN_WARNING("Ты не можешь сконцентрироватся настолько далеко."))
 			return FALSE
 
-		if(target.stat == DEAD || (target.status_flags & FAKEDEATH) || !target.client)
+		if(target.is_dead() || !target.client)
 			to_chat(user, SPAN_WARNING("[target] не в состоянии ответить вам."))
 			return FALSE
 

--- a/mods/psionics/code/faculties/redaction.dm
+++ b/mods/psionics/code/faculties/redaction.dm
@@ -12,7 +12,7 @@
 /singleton/psionic_power/redaction/proc/check_dead(mob/living/target)
 	if(!istype(target))
 		return FALSE
-	if(target.stat == DEAD || (target.status_flags & FAKEDEATH))
+	if(target.is_dead())
 		return TRUE
 	return FALSE
 
@@ -277,7 +277,7 @@
 		return FALSE
 	. = ..()
 	if(.)
-		if(target.stat != DEAD && !(target.status_flags & FAKEDEATH))
+		if(!target.is_dead())
 			to_chat(user, SPAN_WARNING("Этот человек ещё жив!"))
 			return TRUE
 


### PR DESCRIPTION
<!-- ЗДЕСЬ должно быть **подробное описание** того, что происходит в PR и зачем это нужно. PR не должен содержать изменений, о которых здесь ничего не сказано. -->
https://github.com/Baystation12/Baystation12/pull/35354/

Изменяет проверки на фейковую смерть во множестве мест, чтобы фейковая смерть еще больше была похожей на настоящую. Например: фейковая смерть больше не определяется фонариком в глаза, фейковая смерть вызывает срабатывание импланта оповещения о смерти и системы самоуничтожения РИГа, фейковой смертью теперь можно обмануть некоторых мобов и тд.

Касается зомби порошка и стазиса ченджлинга.

Проки:
is_dead() - возвращает TRUE при любом виде смерти, в том числе при фейковой смерти
is_real_dead() - возвращает TRUE только при реальной смерти

<!-- ЗДЕСЬ нужно **привязать ишью**, которые относятся к PR'у в формате `close #1234` или `fixes #1234` - тогда они автоматически закроются вместе с PR. Можно написать `Затрагивает #1234, но не фиксит его`, если вы просто хотите упоминуть ишью, но не закрывать его. -->
close #0

<!-- ЗДЕСЬ нужно **расписать изменения** которые попадут в **чейнджлог**, формат - `prefix: краткое описание` -->
### Чейнджлог
```yml
🆑SierraKomodo
tweak: Various things that check if a mob is dead now also look at faked deaths as well. This should make it harder to accidentally/intentionally meta ling death.
/🆑
```

<!--
  Честно заполняем галочки. Чем больше галочек, тем быстрее проверять Pull Request, соответственно он быстрее будет принят.
  Чтобы отметить - ставим `x` (икс) внутри квадратных скобочек вот так: `- [x] ...`.
  Галочки можно доставлять позже по мере окончания работы над PR'ом.
-->

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
