### PR TITLE
Фикс экстренных подов

### DIFF
--- a/mods/utility_items/code/shuttles/pods_landing.dm
+++ b/mods/utility_items/code/shuttles/pods_landing.dm
@@ -53,7 +53,8 @@
 
 /obj/shuttle_landmark/escape_pod/out/New()
 	.=..()
-	landmark_tag = "Nav_[name] - [rand(1, 1000)]"
+	if(GAME_STATE >= RUNLEVEL_GAME) // Fixing transit landmarks
+		landmark_tag = "Nav_[name] - [rand(1, 1000)]"
 
 
 //////////////////////////ESCAPE POD////////////////////////////
@@ -178,12 +179,21 @@
 			if(visit.map_z in possible_visits)
 				continue
 			possible_visits += visit
+
+	possible_visits += "Outer Space"
 	if(length(possible_visits))
 		destination_pod = input("Choose pod destination", "Pod Destination") as null|anything in possible_visits
+
+		if(destination_pod == "Outer Space")
+			linked.pod.next_location = linked.pod.waypoint_offsite
+			linked.pod.destination_chosen = TRUE
+			state("Pod destination set to outer space.")
+			return
 	else
 		linked.pod.next_location = linked.pod.waypoint_offsite
 		state("Pod destination set to outer space.")
 		return
+
 	var/x_destination = pick(rand(40, 160))
 	var/y_destination = pick(rand(40, 160))
 	var/z_destination = pick(destination_pod.map_z)
@@ -209,9 +219,9 @@
 
 
 
-/datum/evacuation_controller/starship/fast/finish_preparing_evac()
+/*/datum/evacuation_controller/starship/fast/finish_preparing_evac()
 	. = ..()
 	for (var/datum/shuttle/autodock/ferry/escape_pod/pod in escape_pods)
 		if (pod.arming_controller)
 			pod.arming_controller.arm()
-			pod.get_possible_destination()
+			pod.get_possible_destination()*/


### PR DESCRIPTION
<!-- ЗДЕСЬ должно быть **подробное описание** того, что происходит в PR и зачем это нужно. PR не должен содержать изменений, о которых здесь ничего не сказано. -->
Фиксит открытие подов при блуспейс прыжке. (Тестил обе эвакуации - через подтверждение картой и через консоль)

В качестве небольшого бонуса еще пофиксил ландмарки транзитного уровня и добавил на консоли выбора локации опцию 'Outer Space' - которая отправляет под в ту локацию, которая у него была до мода.

<!-- ЗДЕСЬ нужно **привязать ишью**, которые относятся к PR'у в формате `close #1234` или `fixes #1234` - тогда они автоматически закроются вместе с PR. Можно написать `Затрагивает #1234, но не фиксит его`, если вы просто хотите упоминуть ишью, но не закрывать его. -->
close #4133

<!-- ЗДЕСЬ нужно **расписать изменения** которые попадут в **чейнджлог**, формат - `prefix: краткое описание` -->
### Чейнджлог
```yml
🆑Builder13
bugfix: Фикс открытия пода эвакуации при прыжке
/🆑
```

<!--
  Честно заполняем галочки. Чем больше галочек, тем быстрее проверять Pull Request, соответственно он быстрее будет принят.
  Чтобы отметить - ставим `x` (икс) внутри квадратных скобочек вот так: `- [x] ...`.
  Галочки можно доставлять позже по мере окончания работы над PR'ом.
-->

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
