### PR TITLE
Вариант спасательных подов

### DIFF
--- a/mods/utility_items/code/shuttles/pods_landing.dm
+++ b/mods/utility_items/code/shuttles/pods_landing.dm
@@ -89,7 +89,7 @@
 	.=..()
 	var/datum/computer/file/embedded_program/docking/simple/prog = SSshuttle.docking_registry[dock_target]
 	pod_controller = prog.master
-
+	next_location = null //have to choose it
 
 /datum/shuttle/autodock/ferry/escape_pod/proc/get_possible_destination()
 	if(destination_chosen)
@@ -180,7 +180,7 @@
 				continue
 			possible_visits += visit
 
-	possible_visits += "Outer Space"
+	//possible_visits += "Outer Space"
 	if(length(possible_visits))
 		destination_pod = input("Choose pod destination", "Pod Destination") as null|anything in possible_visits
 


### PR DESCRIPTION
<!-- ЗДЕСЬ должно быть **подробное описание** того, что происходит в PR и зачем это нужно. PR не должен содержать изменений, о которых здесь ничего не сказано. -->
ПР на случай если так будет нужно.

-Поды опять больше никуда не улетают, до того как в них не укажут назначение, даже при эвакуации (Так было до моих изменений, поды никуда не улетали, так как из-за бага у них отсутствовал оригинальный waypoint для outer space)
-Outer space убран из выбора. Выбрать его можно только если авеек нет

Я понимаю почему эти изменения могут быть интересны, люди будут улетать не куда-то на транзитную карту, недоступную для взаимодействия, а оставаться на существующих авейках и возможно еще и разнообразит само прибытие подов, так как они и в друг друга влететь могут, и еще в какую-нибудь структуру.

Но эти изменения также могут и задавать вопросы, больше по ИЦ части:
1. Почему спасательные поды могут летать только по перечню авеек? - почему под обязательно должен подлететь к какому-то значимому астероиду, заброшенной станции или еще чему-либо для эвакуации? Как это ограничение обосновывается? Особенно актуально когда под впишется на полном ходу в структуру единственно доступной заброшенной станции для выбора.
2. Ситуативные ограничения - за Сиеррой погнались технологически продвинутые жуки, вывели оборудование из строя и теперь происходит эвакуация. Заходим в под и он нам предлагает опять же неудачный сценарий десантирования прямо к жукам на подах и ничего более. Почему даже в той ситуации, когда мы знаем об опасности - мы не имеем возможности альтернативной эвакуации? (но при этом сама ситуация конечно интересная)
3. Под все же может в обычный космос перемещаться - когда авеек рядом нет, под все же получает возможность просто в открытый космос прыгнуть, вопрос, а почему так раньше нельзя было?

Контраргументом может являться то, что иначе outer space может стать более популярным вариантом (за счет того что локацию например вообще не будут проставлять, или проставлять, но только ее), без каких-либо рисков. И тогда поды только и будут на свою изначальную локацию летать, и смысл мода тогда потеряется. Тут смотря как по итогу лучше.
<!-- ЗДЕСЬ нужно **привязать ишью**, которые относятся к PR'у в формате `close #1234` или `fixes #1234` - тогда они автоматически закроются вместе с PR. Можно написать `Затрагивает #1234, но не фиксит его`, если вы просто хотите упоминуть ишью, но не закрывать его. -->
close #0

<!-- ЗДЕСЬ нужно **расписать изменения** которые попадут в **чейнджлог**, формат - `prefix: краткое описание` -->
### Чейнджлог
```yml
🆑Builder13
tweak: Поды вновь не улетают без выбора точки назначения, outer space убран из прямого выбора у подов
/🆑
```

<!--
  Честно заполняем галочки. Чем больше галочек, тем быстрее проверять Pull Request, соответственно он быстрее будет принят.
  Чтобы отметить - ставим `x` (икс) внутри квадратных скобочек вот так: `- [x] ...`.
  Галочки можно доставлять позже по мере окончания работы над PR'ом.
-->

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
