### PR TITLE
Фикс консоли выбора назначения спасательного пода

### DIFF
--- a/mods/utility_items/code/shuttles/pods_landing.dm
+++ b/mods/utility_items/code/shuttles/pods_landing.dm
@@ -161,7 +161,8 @@
 			to_chat(usr, SPAN_WARNING("No escape pod controller found nearby."))
 			return
 	else
-		get_possible_destinations()
+		if(CanPhysicallyInteractWith(usr, src))
+			get_possible_destinations()
 
 /obj/machinery/pod_set_destination/proc/get_possible_destinations()
 	if(linked.pod.current_location != linked.pod.waypoint_station)


### PR DESCRIPTION
<!-- ЗДЕСЬ должно быть **подробное описание** того, что происходит в PR и зачем это нужно. PR не должен содержать изменений, о которых здесь ничего не сказано. -->
Призраки больше не могут проставлять локацию на консоли спасательных подов.

<!-- ЗДЕСЬ нужно **привязать ишью**, которые относятся к PR'у в формате `close #1234` или `fixes #1234` - тогда они автоматически закроются вместе с PR. Можно написать `Затрагивает #1234, но не фиксит его`, если вы просто хотите упоминуть ишью, но не закрывать его. -->
close #0

<!-- ЗДЕСЬ нужно **расписать изменения** которые попадут в **чейнджлог**, формат - `prefix: краткое описание` -->
### Чейнджлог
```yml
🆑Builder13
bugfix: Призраки больше не могут проставлять локацию на консоли спасательных подов.
/🆑
```

<!--
  Честно заполняем галочки. Чем больше галочек, тем быстрее проверять Pull Request, соответственно он быстрее будет принят.
  Чтобы отметить - ставим `x` (икс) внутри квадратных скобочек вот так: `- [x] ...`.
  Галочки можно доставлять позже по мере окончания работы над PR'ом.
-->

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
