### PR TITLE
Fix: Исправление SQL синтаксиса

### DIFF
--- a/mods/ex666_ecosystem/code/experience/subsystem.dm
+++ b/mods/ex666_ecosystem/code/experience/subsystem.dm
@@ -163,8 +163,8 @@ SUBSYSTEM_DEF(experience)
 		var/DBQuery/player_update_query = dbcon.NewQuery({"
 			UPDATE `erro_player`
 			SET
-				`exp` = [updated_exp],
-				`species_exp` = [updated_species_exp],
+				`exp` = '[updated_exp]',
+				`species_exp` = '[updated_species_exp]',
 				`lastseen` = NOW()
 			WHERE
 				`ckey` = '[sql_ckey]'


### PR DESCRIPTION
Может быть починит бд, ура?
Добавляет всего четыре кавычки


### Чейнджлог
```yml
🆑PinkVulp
bugfix: Часы на должностях должны сохранятся
/🆑
```

<!--
  Честно заполняем галочки. Чем больше галочек, тем быстрее проверять Pull Request, соответственно он быстрее будет принят.
  Чтобы отметить - ставим `x` (икс) внутри квадратных скобочек вот так: `- [x] ...`.
  Галочки можно доставлять позже по мере окончания работы над PR'ом.
-->

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
