### PR TITLE
Кнопочки для шепота

### DIFF
--- a/code/controllers/subsystems/typing.dm
+++ b/code/controllers/subsystems/typing.dm
@@ -233,3 +233,13 @@ SUBSYSTEM_DEF(typing)
 	SStyping.UpdateVerbState(client, FALSE)
 	if (message)
 		me_verb(message)
+
+
+/mob/verb/whisper_wrapper()
+	set name = ".Whisper"
+	set hidden = TRUE
+	SStyping.UpdateVerbState(client, TRUE)
+	var/message = input("","whisper (text)") as null | text
+	SStyping.UpdateVerbState(client, FALSE)
+	if (message)
+		whisper(message)

--- a/code/controllers/subsystems/typing.dm
+++ b/code/controllers/subsystems/typing.dm
@@ -224,6 +224,14 @@ SUBSYSTEM_DEF(typing)
 	if (message)
 		say_verb(message)
 
+/mob/verb/whisper_wrapper()
+	set name = ".Whisper"
+	set hidden = TRUE
+	SStyping.UpdateVerbState(client, TRUE)
+	var/message = input("","whisper (text)") as null | text
+	SStyping.UpdateVerbState(client, FALSE)
+	if (message)
+		whisper(message)
 
 /mob/verb/me_wrapper()
 	set name = ".Me"

--- a/code/controllers/subsystems/typing.dm
+++ b/code/controllers/subsystems/typing.dm
@@ -224,14 +224,6 @@ SUBSYSTEM_DEF(typing)
 	if (message)
 		say_verb(message)
 
-/mob/verb/whisper_wrapper()
-	set name = ".Whisper"
-	set hidden = TRUE
-	SStyping.UpdateVerbState(client, TRUE)
-	var/message = input("","whisper (text)") as null | text
-	SStyping.UpdateVerbState(client, FALSE)
-	if (message)
-		whisper(message)
 
 /mob/verb/me_wrapper()
 	set name = ".Me"

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -164,6 +164,9 @@ macro "macro"
 		name = "F3"
 		command = ".say"
 	elem
+		name = "Shift+T"
+		command = ".whisper"
+	elem
 		name = "F4"
 		command = ".me"
 	elem

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -164,9 +164,6 @@ macro "macro"
 		name = "F3"
 		command = ".say"
 	elem
-		name = "Shift+T"
-		command = ".whisper"
-	elem
 		name = "F4"
 		command = ".me"
 	elem

--- a/mods/ssinput/code/keybindings/communication.dm
+++ b/mods/ssinput/code/keybindings/communication.dm
@@ -21,6 +21,15 @@
 	user.mob.whisper_wrapper()
 	return TRUE
 
+/mob/verb/whisper_wrapper()
+	set name = ".Whisper"
+	set hidden = TRUE
+	SStyping.UpdateVerbState(client, TRUE)
+	var/message = input("","whisper (text)") as null | text
+	SStyping.UpdateVerbState(client, FALSE)
+	if (message)
+		whisper(message)
+
 
 /datum/keybinding/client/communication/ooc
 	hotkey_keys = list("F2")

--- a/mods/ssinput/code/keybindings/communication.dm
+++ b/mods/ssinput/code/keybindings/communication.dm
@@ -7,9 +7,18 @@
 	name = "IC Say"
 	full_name = "IC Say"
 
-
 /datum/keybinding/client/communication/say/down(client/user)
 	user.mob.say_wrapper()
+	return TRUE
+
+
+/datum/keybinding/client/communication/whisper
+	hotkey_keys = list("ShiftT")
+	name = "IC Whisper"
+	full_name = "IC Whisper"
+
+/datum/keybinding/client/communication/whisper/down(client/user)
+	user.mob.whisper_wrapper()
 	return TRUE
 
 
@@ -24,7 +33,6 @@
 	name = "LOOC"
 	full_name = "Local Out Of Character Say (LOOC)"
 
-
 /datum/keybinding/client/communication/looc/down(client/user)
 	user.looc()
 	return TRUE
@@ -34,7 +42,6 @@
 	hotkey_keys = list("F4", "M", "5")
 	name = "IC Me"
 	full_name = "Custom Emote (/Me)"
-
 
 /datum/keybinding/client/communication/me/down(client/user)
 	user.mob.me_wrapper()

--- a/mods/ssinput/code/keybindings/communication.dm
+++ b/mods/ssinput/code/keybindings/communication.dm
@@ -21,6 +21,7 @@
 	user.mob.whisper_wrapper()
 	return TRUE
 
+// оставил верб тут, хз куда его можно запихнуть
 /mob/verb/whisper_wrapper()
 	set name = ".Whisper"
 	set hidden = TRUE

--- a/mods/ssinput/code/keybindings/communication.dm
+++ b/mods/ssinput/code/keybindings/communication.dm
@@ -7,6 +7,7 @@
 	name = "IC Say"
 	full_name = "IC Say"
 
+
 /datum/keybinding/client/communication/say/down(client/user)
 	user.mob.say_wrapper()
 	return TRUE
@@ -21,16 +22,6 @@
 	user.mob.whisper_wrapper()
 	return TRUE
 
-// оставил верб тут, хз куда его можно запихнуть
-/mob/verb/whisper_wrapper()
-	set name = ".Whisper"
-	set hidden = TRUE
-	SStyping.UpdateVerbState(client, TRUE)
-	var/message = input("","whisper (text)") as null | text
-	SStyping.UpdateVerbState(client, FALSE)
-	if (message)
-		whisper(message)
-
 
 /datum/keybinding/client/communication/ooc
 	hotkey_keys = list("F2")
@@ -43,6 +34,7 @@
 	name = "LOOC"
 	full_name = "Local Out Of Character Say (LOOC)"
 
+
 /datum/keybinding/client/communication/looc/down(client/user)
 	user.looc()
 	return TRUE
@@ -52,6 +44,7 @@
 	hotkey_keys = list("F4", "M", "5")
 	name = "IC Me"
 	full_name = "Custom Emote (/Me)"
+
 
 /datum/keybinding/client/communication/me/down(client/user)
 	user.mob.me_wrapper()


### PR DESCRIPTION
<!-- ЗДЕСЬ должно быть **подробное описание** того, что происходит в PR и зачем это нужно. PR не должен содержать изменений, о которых здесь ничего не сказано. -->

Добавляет хоткей для шепота (по умолчанию Shift+T), чтобы типы не тратили время на прокликивание верба в IC панели, если вдруг захотят пошептать друг другу на ушко.

Удалось обойтись одним файлом в модах билда. Наверное, стоит вписать хоткей также и в корневой skin.dmf, но ВРОДЕ БЫ работает и без этого: окошко вызывается без рантаймов, в настройках бинд появился и послушно меняется.

<img width="1041" height="160" alt="изображение" src="https://github.com/user-attachments/assets/1511e0c8-96e3-4ba8-ae7f-2f246d5cc6a3" />

<!-- ЗДЕСЬ нужно **расписать изменения** которые попадут в **чейнджлог**, формат - `prefix: краткое описание` -->
### Чейнджлог
```yml
🆑Osetrokarasek
rscadd: Добавлена горячая клавиша для шёпота (по умолчанию Shift+T).
/🆑
```

<!--
  Честно заполняем галочки. Чем больше галочек, тем быстрее проверять Pull Request, соответственно он быстрее будет принят.
  Чтобы отметить - ставим `x` (икс) внутри квадратных скобочек вот так: `- [x] ...`.
  Галочки можно доставлять позже по мере окончания работы над PR'ом.
-->

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
