### PR TITLE
Fix: Crash Game Server - Do not wish to be crashed anymore

### DIFF
--- a/mods/_master_files/code/modules/client/preferences_persist.dm
+++ b/mods/_master_files/code/modules/client/preferences_persist.dm
@@ -3,14 +3,12 @@
 	var/text = json_encode(data)
 
 	if(isnull(text))
-		// Log JSON encoding error but don't crash the server
 		log_error("JSON encode failed for [path] | Ckey: [client_ckey] | Record: [record_key]")
 		message_admins("JSON encode failed for [path] | Ckey: [client_ckey] | Record: [record_key]")
 		return
 
 	var/error = rustg_file_write(text, path)
 	if (error)
-		// Log error details for debugging but don't crash the server
 		log_error("Preferences save failed: [error] | Path: [path] | Ckey: [client_ckey] | Record: [record_key] | Text length: [length(text)]")
 		message_admins("Preferences save failed: [error] | Path: [path] | Ckey: [client_ckey] | Record: [record_key] | Text length: [length(text)]")
 		return

--- a/mods/_master_files/code/modules/client/preferences_persist.dm
+++ b/mods/_master_files/code/modules/client/preferences_persist.dm
@@ -3,9 +3,14 @@
 	var/text = json_encode(data)
 
 	if(isnull(text))
-		crash_with("Failed to encode JSON for [path]")
+		// Log JSON encoding error but don't crash the server
+		log_error("JSON encode failed for [path] | Ckey: [client_ckey] | Record: [record_key]")
+		message_admins("JSON encode failed for [path] | Ckey: [client_ckey] | Record: [record_key]")
 		return
 
 	var/error = rustg_file_write(text, path)
 	if (error)
-		crash_with(error)
+		// Log error details for debugging but don't crash the server
+		log_error("Preferences save failed: [error] | Path: [path] | Ckey: [client_ckey] | Record: [record_key] | Text length: [length(text)]")
+		message_admins("Preferences save failed: [error] | Path: [path] | Ckey: [client_ckey] | Record: [record_key] | Text length: [length(text)]")
+		return


### PR DESCRIPTION
Убираем код, что позволяет вызывать краш сервера. Взамен устанавливаем логирование для отслеживания подобных проблем.

🆑
bugfix: Заменены краши сервера на логирование ошибок при сохранении настроек
/🆑

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.