### PR TITLE
FIX: Try to fix crash game & Add logs pAI

### DIFF
--- a/code/modules/mob/living/silicon/pai/personality.dm
+++ b/code/modules/mob/living/silicon/pai/personality.dm
@@ -16,6 +16,13 @@
 	if(IsGuestKey(user.key))
 		return 0
 
+	// [SIERRA-ADD] - На этом моменте происходил рантайм, так как по каким-то причинам usr был null. В теории это решит проблему.
+	if(!usr || usr == "the new player")
+		log_admin("CharacterSetup: [user] попытался сохранить pAI, но что-то пошло не так.")
+		return 0
+	log_debug("CharacterSetup: [user] сохраняет pAI персонажа. usr = [usr], user = [user], name_drone = [src]")
+	// [/SIERRA-ADD]
+
 	var/savefile/F = new /savefile(src.savefile_path(user))
 
 	to_save(F["name"], src.name)


### PR DESCRIPTION
Исправляем рантайм, когда "usr" по непонятным причинам приходит null. Возможно исправит проблему краша. 
Также добавил логирование для pAI, чтобы отслеживать подобные моменты в будущем более детально.

По хорошему после выяснения и исправления крашей убрать логирование, что было добавлено здесь и в https://github.com/SierraBay/SierraBay12/pull/4413

<!-- ЗДЕСЬ нужно **расписать изменения** которые попадут в **чейнджлог**, формат - `prefix: краткое описание` -->
### Чейнджлог
```yml
🆑Mr_DarkBladeS
wip: Добавлено логирование сохранения pAI для отслеживания крашей.
/🆑
```

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
