### PR TITLE
[MAP] Merc missile bay and event maps mirroring

### DIFF
--- a/code/modules/modular_computers/computers/subtypes/preset_console.dm
+++ b/code/modules/modular_computers/computers/subtypes/preset_console.dm
@@ -100,6 +100,11 @@
 		/datum/computer_file/program/munitions
 	)
 
+/obj/machinery/computer/modular/preset/munitions/syndicate
+	default_software = list(
+		/datum/computer_file/program/munitions/syndicate
+	)
+
 /obj/machinery/computer/modular/preset/cardslot/command_eng
 	default_software = list(
 		/datum/computer_file/program/comm,

--- a/code/modules/modular_computers/file_system/programs/command/munitions.dm
+++ b/code/modules/modular_computers/file_system/programs/command/munitions.dm
@@ -13,11 +13,19 @@
 	requires_ntnet_feature = NTNET_SYSTEMCONTROL
 	required_access = access_bridge
 
+/datum/computer_file/program/munitions/syndicate
+	nanomodule_path = /datum/nano_module/program/munitions/syndicate
+	required_access = access_syndicate
+	available_on_ntnet = FALSE
+
 /datum/nano_module/program/munitions
 	name = "Munitions Control Program"
 	var/access_req = list(access_bridge)
 	var/list/monitored_munitions = list()
 	var/obj/overmap/visitable/linked = null
+
+/datum/nano_module/program/munitions/syndicate
+	access_req = list(access_syndicate)
 
 /datum/nano_module/program/munitions/New()
 	..()

--- a/maps/antag_spawn/mercenary/mercenary_base.dmm
+++ b/maps/antag_spawn/mercenary/mercenary_base.dmm
@@ -278,7 +278,7 @@
 /turf/simulated/floor/plating,
 /area/map_template/merc_shuttle)
 "cM" = (
-/obj/machinery/computer/ship/engines{
+/obj/machinery/computer/modular/preset/helm{
 	uncreated_component_parts = list(/obj/item/stock_parts/power/battery/buildable/responsive=1,/obj/item/cell/high=1)
 	},
 /obj/item/device/radio/intercom/hailing{
@@ -299,7 +299,7 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/merc_shuttle)
 "cS" = (
-/obj/machinery/computer/ship/navigation,
+/obj/machinery/computer/modular/preset/navigation,
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/merc_shuttle)
 "cT" = (
@@ -745,7 +745,7 @@
 /obj/structure/bed/chair/shuttle/blue{
 	dir = 8
 	},
-/obj/machinery/computer/ship/navigation/telescreen{
+/obj/item/modular_computer/telescreen/preset/navigation{
 	pixel_y = -32
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -2533,7 +2533,7 @@
 /obj/floor_decal/techfloor{
 	dir = 4
 	},
-/obj/machinery/computer/ship/sensors/spacer{
+/obj/machinery/computer/modular/preset/sensors/spacer{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
@@ -3047,7 +3047,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
 	dir = 1
 	},
-/obj/machinery/computer/ship/engines{
+/obj/machinery/computer/modular/preset/helm{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,

--- a/maps/antag_spawn/mercenary/mercenary_base.dmm
+++ b/maps/antag_spawn/mercenary/mercenary_base.dmm
@@ -186,13 +186,6 @@
 /obj/catwalk_plated,
 /turf/simulated/floor/plating,
 /area/map_template/merc_spawn)
-"bz" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 6
-	},
-/obj/machinery/portable_atmospherics/powered/pump/filled,
-/turf/simulated/floor/tiled/techfloor,
-/area/map_template/merc_shuttle)
 "bM" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -271,12 +264,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/map_template/merc_shuttle)
-"cH" = (
-/obj/machinery/door/blast/regular{
-	id_tag = "merc_bsa"
-	},
-/turf/simulated/floor/plating,
-/area/map_template/merc_shuttle)
 "cI" = (
 /obj/wallframe_spawn/reinforced/titanium,
 /obj/machinery/atmospherics/pipe/simple/hidden/universal{
@@ -285,14 +272,13 @@
 /obj/machinery/door/blast/regular/open{
 	density = 0;
 	dir = 4;
-	icon_state = "pdoor0";
 	id_tag = "merc_external"
 	},
 /obj/paint/merc,
 /turf/simulated/floor/plating,
 /area/map_template/merc_shuttle)
 "cM" = (
-/obj/machinery/computer/modular/preset/helm{
+/obj/machinery/computer/ship/engines{
 	uncreated_component_parts = list(/obj/item/stock_parts/power/battery/buildable/responsive=1,/obj/item/cell/high=1)
 	},
 /obj/item/device/radio/intercom/hailing{
@@ -308,18 +294,12 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/merc_shuttle)
-"cO" = (
-/obj/machinery/disperser/front{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/map_template/merc_shuttle)
 "cQ" = (
-/obj/machinery/computer/ship/disperser,
+/obj/machinery/computer/modular/preset/munitions/syndicate,
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/merc_shuttle)
 "cS" = (
-/obj/machinery/computer/modular/preset/navigation,
+/obj/machinery/computer/ship/navigation,
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/merc_shuttle)
 "cT" = (
@@ -356,10 +336,10 @@
 /turf/simulated/floor/tiled/white,
 /area/map_template/merc_spawn)
 "dn" = (
-/obj/machinery/disperser/middle{
-	dir = 1
+/obj/machinery/door/blast/regular{
+	id_tag = "merc_pod"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/airless,
 /area/map_template/merc_shuttle)
 "dq" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -412,15 +392,15 @@
 "em" = (
 /obj/structure/table/steel_reinforced,
 /obj/machinery/button/blast_door{
-	id_tag = "merc_bsa";
-	name = "OFD Firing Blast Doors";
+	id_tag = "merc_pod_access";
+	name = "Missile Pod Access";
 	pixel_x = -5;
 	pixel_y = 6;
 	req_access = list("ACCESS_SYNDICATE")
 	},
 /obj/machinery/button/blast_door{
 	id_tag = "merc_bsa_shutters";
-	name = "OFD Viewing Shutters";
+	name = "Missile Pod Viewing Shutters";
 	pixel_x = -5;
 	pixel_y = -3;
 	req_access = list("ACCESS_SYNDICATE")
@@ -453,15 +433,6 @@
 /obj/floor_decal/techfloor/corner{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
 /turf/simulated/floor/tiled/dark,
 /area/map_template/merc_shuttle)
 "ex" = (
@@ -480,11 +451,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/map_template/merc_shuttle)
 "eG" = (
-/obj/machinery/disperser/back{
-	dir = 1
+/obj/machinery/payload_interface{
+	name = "Missile Pod";
+	id_tag = "merc_pod";
+	allow_arming = 1
 	},
-/obj/structure/ship_munition/disperser_charge/emp,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/airless,
 /area/map_template/merc_shuttle)
 "eR" = (
 /obj/machinery/cryopod{
@@ -512,7 +484,6 @@
 /obj/machinery/door/blast/regular/open{
 	density = 0;
 	dir = 4;
-	icon_state = "pdoor0";
 	id_tag = "merc_bsa_shutters"
 	},
 /obj/paint/merc,
@@ -602,16 +573,17 @@
 /turf/simulated/floor/plating,
 /area/map_template/merc_spawn)
 "gr" = (
-/obj/machinery/door/blast/regular/open{
-	density = 0;
-	icon_state = "pdoor0";
-	id_tag = "merc_bsa"
-	},
 /obj/floor_decal/industrial/warning{
 	dir = 8
 	},
 /obj/floor_decal/industrial/warning{
 	dir = 4
+	},
+/obj/machinery/door/blast/regular{
+	id_tag = "merc_pod_access";
+	name = "missile pod";
+	density = 0;
+	icon_state = "pdoor0"
 	},
 /turf/simulated/floor/plating,
 /area/map_template/merc_shuttle)
@@ -773,7 +745,7 @@
 /obj/structure/bed/chair/shuttle/blue{
 	dir = 8
 	},
-/obj/item/modular_computer/telescreen/preset/navigation{
+/obj/machinery/computer/ship/navigation/telescreen{
 	pixel_y = -32
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -871,8 +843,8 @@
 /turf/simulated/floor/tiled/monotile,
 /area/map_template/merc_spawn)
 "jK" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark,
 /area/map_template/merc_shuttle)
 "jQ" = (
@@ -901,22 +873,10 @@
 	frequency = 1380;
 	master_tag = "merc_shuttle";
 	name = "interior access button";
-	pixel_x = 29;
+	pixel_x = 22;
 	pixel_y = -11
 	},
 /turf/simulated/floor/tiled/dark,
-/area/map_template/merc_shuttle)
-"ka" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/dark/monotile,
 /area/map_template/merc_shuttle)
 "kb" = (
 /turf/simulated/floor/tiled/dark,
@@ -1025,21 +985,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/item/device/binoculars,
-/obj/item/device/binoculars,
-/obj/item/device/binoculars,
-/obj/item/device/binoculars,
-/obj/item/device/binoculars,
-/obj/item/device/binoculars,
-/obj/item/device/binoculars,
-/obj/item/crowbar/prybar,
-/obj/item/crowbar/prybar,
-/obj/item/crowbar/prybar,
-/obj/item/crowbar/prybar,
-/obj/item/crowbar/prybar,
-/obj/item/crowbar/prybar,
-/obj/item/crowbar/prybar,
-/obj/item/crowbar/prybar,
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/merc_shuttle)
 "lg" = (
@@ -1089,6 +1034,9 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/merc_shuttle)
 "lz" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
+	},
 /obj/floor_decal/industrial/warning{
 	dir = 4
 	},
@@ -1096,9 +1044,6 @@
 	dir = 8
 	},
 /obj/structure/handrail{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -1111,10 +1056,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
-/area/map_template/merc_shuttle)
-"lS" = (
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/fuel,
-/turf/simulated/floor/tiled/techfloor,
 /area/map_template/merc_shuttle)
 "lX" = (
 /obj/floor_decal/corner/blue{
@@ -1132,7 +1073,6 @@
 /obj/machinery/door/blast/regular/open{
 	density = 0;
 	dir = 4;
-	icon_state = "pdoor0";
 	id_tag = "merc_airlock"
 	},
 /obj/paint/merc,
@@ -1170,7 +1110,6 @@
 /obj/machinery/door/blast/regular/open{
 	density = 0;
 	dir = 4;
-	icon_state = "pdoor0";
 	id_tag = "merc_external"
 	},
 /obj/paint/merc,
@@ -1271,13 +1210,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/fabricator/hacked,
-/obj/floor_decal/industrial/outline/yellow,
-/obj/item/stack/material/steel/ten,
-/obj/item/stack/material/steel/ten,
-/obj/item/stack/material/glass/ten,
-/obj/item/stack/material/aluminium/ten,
-/obj/item/stack/material/plastic/ten,
+/obj/structure/table/steel_reinforced,
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/merc_shuttle)
 "nn" = (
@@ -1371,12 +1304,11 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/merc_shuttle)
 "oo" = (
-/obj/machinery/body_scanconsole{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/white,
+/obj/machinery/portable_atmospherics/canister/hydrogen,
+/obj/floor_decal/industrial/outline/yellow,
+/obj/item/tank/hydrogen,
+/obj/item/tank/hydrogen,
+/turf/simulated/floor/tiled/techfloor,
 /area/map_template/merc_shuttle)
 "oC" = (
 /obj/machinery/door/airlock/external{
@@ -1406,11 +1338,6 @@
 /obj/overmap/visitable/sector/merc_base,
 /turf/simulated/floor/plating,
 /area/map_template/merc_spawn)
-"oJ" = (
-/obj/paint/sun,
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
-/turf/simulated/wall/titanium,
-/area/map_template/merc_shuttle)
 "oK" = (
 /obj/floor_decal/corner/blue/mono,
 /obj/structure/table/standard,
@@ -1423,15 +1350,6 @@
 	dir = 1;
 	pixel_y = -24;
 	req_access = list("ACCESS_SYNDICATE")
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/map_template/merc_shuttle)
@@ -1457,18 +1375,35 @@
 /turf/simulated/floor/tiled,
 /area/map_template/merc_spawn)
 "pb" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 6
+	},
 /obj/floor_decal/corner_techfloor_grid{
 	dir = 1
 	},
 /obj/floor_decal/techfloor/corner{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
 /turf/simulated/floor/tiled/dark,
 /area/map_template/merc_shuttle)
 "pc" = (
+/obj/structure/table/steel,
+/obj/item/crowbar/prybar,
+/obj/item/crowbar/prybar,
+/obj/item/crowbar/prybar,
+/obj/item/crowbar/prybar,
+/obj/item/crowbar/prybar,
+/obj/item/crowbar/prybar,
+/obj/machinery/button/blast_door{
+	id_tag = "merc_airlock";
+	req_access = list("ACCESS_SYNDICATE")
+	},
+/obj/item/device/binoculars,
+/obj/item/device/binoculars,
+/obj/item/device/binoculars,
+/obj/item/device/binoculars,
+/obj/item/device/binoculars,
+/obj/item/device/binoculars,
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
@@ -1480,7 +1415,6 @@
 /obj/machinery/door/blast/regular/open{
 	density = 0;
 	dir = 4;
-	icon_state = "pdoor0";
 	id_tag = "merc_airlock"
 	},
 /obj/paint/merc,
@@ -1538,7 +1472,6 @@
 /obj/machinery/door/blast/regular/open{
 	density = 0;
 	dir = 4;
-	icon_state = "pdoor0";
 	id_tag = "merc_external"
 	},
 /obj/paint/merc,
@@ -1560,36 +1493,54 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/map_template/merc_shuttle)
 "qj" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/structure/window/reinforced/crescent{
 	dir = 4
 	},
-/obj/machinery/computer/modular/preset/helm,
-/turf/simulated/floor/tiled/techfloor,
+/obj/structure/bed/chair/shuttle/black{
+	dir = 8
+	},
+/obj/structure/sign/poster{
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/map_template/merc_shuttle)
 "qw" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 9
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/merc_shuttle)
 "qy" = (
-/obj/floor_decal/techfloor{
+/obj/wallframe_spawn/reinforced/titanium,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/button/blast_door{
-	id_tag = "merc_airlock";
-	req_access = list("ACCESS_SYNDICATE");
-	pixel_x = 21;
-	pixel_y = 23
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/paint/merc,
+/turf/simulated/floor/plating,
 /area/map_template/merc_shuttle)
 "qA" = (
-/obj/structure/fuel_port{
-	pixel_y = -30
+/obj/machinery/fabricator/hacked,
+/obj/floor_decal/industrial/outline/yellow,
+/obj/item/stack/material/plastic/ten,
+/obj/item/stack/material/aluminium/ten,
+/obj/item/stack/material/steel/ten,
+/obj/item/stack/material/glass/ten,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/item/stack/material/steel/ten,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/map_template/merc_shuttle)
 "qC" = (
@@ -1598,18 +1549,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/steel_ridged,
 /area/map_template/merc_spawn)
-"qQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/techfloor,
-/area/map_template/merc_shuttle)
 "qY" = (
-/obj/floor_decal/industrial/outline/red,
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/structure/railing,
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/map_template/merc_shuttle)
 "qZ" = (
@@ -1640,28 +1582,19 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/map_template/merc_spawn)
 "rt" = (
+/obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/map_template/merc_shuttle)
-"rx" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/map_template/merc_shuttle)
 "rA" = (
-/obj/machinery/door/airlock/glass,
+/obj/machinery/door/airlock/glass/civilian{
+	name = "airlock"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -1675,27 +1608,26 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+	dir = 10
 	},
-/obj/floor_decal/techfloor/corner{
-	dir = 4
+/obj/machinery/alarm{
+	pixel_y = 24;
+	req_access = list("ACCESS_SYNDICATE")
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/white,
 /area/map_template/merc_shuttle)
 "rG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+/obj/machinery/body_scanconsole{
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
+/obj/structure/handrail,
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/floor_decal/techfloor{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/white,
 /area/map_template/merc_shuttle)
 "rK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -1703,55 +1635,47 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/map_template/merc_spawn)
 "rL" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/map_template/merc_shuttle)
-"rN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/light{
+/obj/structure/window/reinforced/crescent{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/merc_shuttle)
-"sx" = (
-/obj/paint/sun,
-/obj/machinery/atmospherics/unary/engine{
-	dir = 1
+"rN" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
-/turf/simulated/wall/titanium,
+/obj/machinery/recharger/wallcharger{
+	pixel_x = 26
+	},
+/turf/simulated/floor/tiled/techfloor,
 /area/map_template/merc_shuttle)
 "sz" = (
-/obj/machinery/door/airlock/external,
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 4
-	},
-/obj/shuttle_landmark/merc_pod/merc_ship,
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/door/airlock,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/steel_ridged,
 /area/map_template/merc_shuttle)
 "sE" = (
+/obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/paint/merc,
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 4
-	},
 /turf/simulated/wall/titanium,
 /area/map_template/merc_shuttle)
 "sH" = (
-/obj/structure/railing,
-/obj/structure/railing{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
 	},
-/obj/floor_decal/industrial/outline/blue,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/white,
 /area/map_template/merc_shuttle)
 "sO" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
 /area/map_template/merc_shuttle)
 "sS" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -1786,6 +1710,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/machinery/portable_atmospherics/powered/scrubber,
 /turf/simulated/floor/plating,
 /area/map_template/merc_spawn)
 "tO" = (
@@ -1818,29 +1743,37 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/map_template/merc_shuttle)
 "ut" = (
-/obj/paint/red,
-/obj/paint_stripe/white,
-/turf/simulated/wall/r_titanium,
-/area/map_template/merc_shuttle/drop_pod)
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 10
+	},
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/structure/fuel_port{
+	pixel_y = 30
+	},
+/turf/simulated/floor/plating,
+/area/map_template/merc_shuttle)
 "uv" = (
-/obj/floor_decal/techfloor/orange/corner{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/turf/simulated/floor/plating,
+/area/map_template/merc_shuttle)
+"uE" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/obj/floor_decal/techfloor/orange/corner,
-/obj/machinery/door/blast/regular{
-	id_tag = "merc_pod2"
+/obj/structure/catwalk,
+/obj/structure/fuel_port{
+	pixel_y = 30
 	},
-/obj/machinery/button/alternate/pod_doors_explodey{
-	pixel_x = -25;
-	dir = 1;
-	pixel_y = -30
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/map_template/merc_shuttle/drop_pod)
-"uE" = (
-/obj/paint/merc,
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
-/turf/simulated/wall/titanium,
+/turf/simulated/floor/plating,
 /area/map_template/merc_shuttle)
 "uJ" = (
 /obj/structure/closet/crate/freezer,
@@ -1880,21 +1813,28 @@
 /turf/simulated/wall/r_titanium,
 /area/map_template/merc_spawn)
 "uZ" = (
-/obj/machinery/recharger/wallcharger{
-	pixel_x = 26
+/obj/structure/closet/crate{
+	dir = 1;
+	name = "reserve equipment crate"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+/obj/item/stack/material/plasteel/ten,
+/obj/item/stack/material/steel/fifty,
+/obj/item/stack/material/rods/fifty,
+/obj/item/stack/material/glass/reinforced/fifty,
+/obj/item/stack/material/glass/boron_reinforced/ten,
+/obj/item/storage/briefcase/inflatable,
+/obj/item/storage/briefcase/inflatable,
+/obj/item/inflatable_dispenser,
+/obj/item/shuttle_beacon,
+/obj/item/shuttle_beacon,
+/obj/item/shuttle_beacon,
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
+/obj/floor_decal/industrial/warning{
+	dir = 1
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/map_template/merc_shuttle)
-"vb" = (
-/obj/paint/merc,
-/obj/wallframe_spawn/reinforced/titanium,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/map_template/merc_shuttle)
 "vf" = (
 /obj/machinery/light/small{
@@ -1904,8 +1844,6 @@
 /area/map_template/merc_spawn)
 "vm" = (
 /obj/machinery/door/airlock,
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/steel_ridged,
 /area/map_template/merc_shuttle)
@@ -1926,15 +1864,6 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
-/area/map_template/merc_shuttle)
-"vz" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
-	dir = 1
-	},
-/obj/machinery/mech_recharger,
-/obj/floor_decal/industrial/outline/yellow,
-/mob/living/exosuit/premade/light,
-/turf/simulated/floor/tiled/techfloor,
 /area/map_template/merc_shuttle)
 "vA" = (
 /obj/machinery/vitals_monitor,
@@ -1958,8 +1887,9 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/merc_shuttle)
 "vH" = (
-/obj/machinery/pipedispenser,
-/turf/simulated/floor/tiled/techfloor,
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/fuel,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
 /area/map_template/merc_shuttle)
 "vN" = (
 /obj/floor_decal/corner/purple{
@@ -1970,21 +1900,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/map_template/merc_spawn)
 "vO" = (
-/obj/structure/handrail{
-	dir = 4
-	},
-/obj/floor_decal/techfloor/orange{
-	dir = 8
-	},
-/obj/floor_decal/techfloor/orange{
-	dir = 4
-	},
-/obj/machinery/button/blast_door{
-	pixel_x = 23;
-	id_tag = "merc_pod2"
+/obj/structure/catwalk,
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 10
 	},
 /turf/simulated/floor/plating,
-/area/map_template/merc_shuttle/drop_pod)
+/area/map_template/merc_shuttle)
 "wd" = (
 /obj/machinery/sleeper{
 	dir = 4
@@ -2017,47 +1939,14 @@
 /turf/simulated/floor/tiled,
 /area/map_template/merc_spawn)
 "wM" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 6
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/map_template/merc_shuttle)
-"wS" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/structure/closet{
-	name = "tools"
-	},
-/obj/item/gun/energy/plasmacutter,
-/obj/item/storage/belt/utility,
-/obj/item/storage/belt/utility,
-/obj/item/device/paint_sprayer,
-/obj/item/device/paint_sprayer,
-/obj/item/pickaxe/diamonddrill,
-/obj/item/rcd,
-/obj/item/rcd,
-/obj/item/rcd_ammo/large,
-/obj/item/rcd_ammo/large,
-/obj/item/rcd_ammo/large,
-/obj/item/rcd_ammo/large,
-/obj/item/storage/toolbox/syndicate,
-/obj/item/storage/toolbox/syndicate,
-/obj/item/storage/toolbox/syndicate,
-/obj/item/storage/toolbox/syndicate,
-/obj/item/storage/toolbox/syndicate,
+/obj/machinery/portable_atmospherics/powered/pump/filled,
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/merc_shuttle)
 "wW" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/map_template/merc_shuttle)
 "xc" = (
@@ -2086,24 +1975,22 @@
 /turf/simulated/floor/tiled/freezer,
 /area/map_template/merc_spawn)
 "xp" = (
-/obj/paint/merc,
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 6
+	dir = 9
 	},
-/turf/simulated/wall/titanium,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
 /area/map_template/merc_shuttle)
 "xq" = (
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/map_template/merc_shuttle/drop_pod)
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/map_template/merc_shuttle)
 "xt" = (
-/obj/floor_decal/industrial/outline,
-/obj/machinery/atmospherics/portables_connector{
-	dir = 4
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/machinery/portable_atmospherics/canister/air/airlock{
-	start_pressure = 1900
-	},
-/turf/simulated/floor/tiled/techfloor,
+/obj/decal/cleanable/blood/splatter,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/map_template/merc_shuttle)
 "xA" = (
 /obj/structure/closet/medical_wall/filled{
@@ -2137,15 +2024,6 @@
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/map_template/merc_spawn)
-"yh" = (
-/obj/structure/handrail{
-	dir = 4
-	},
-/obj/floor_decal/techfloor/orange{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/map_template/merc_shuttle/drop_pod)
 "yk" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -2153,49 +2031,45 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/merc_spawn)
 "ym" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+/obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
+	dir = 1
 	},
+/obj/machinery/mech_recharger,
+/obj/floor_decal/industrial/outline/yellow,
+/mob/living/exosuit/premade/heavy/merc,
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/merc_shuttle)
 "ys" = (
-/obj/machinery/button/blast_door{
-	pixel_x = -8;
-	id_tag = "merc_pod2";
-	pixel_y = -23
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/light,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/map_template/merc_shuttle)
 "yt" = (
-/obj/structure/table/steel_reinforced,
-/obj/floor_decal/techfloor/orange{
-	dir = 5
+/obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
+	dir = 1
 	},
-/obj/machinery/power/apc/charon{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24;
-	req_access = null
+/obj/structure/closet{
+	name = "tools"
 	},
-/obj/random/powercell{
-	pixel_y = 7
-	},
-/obj/random/powercell{
-	pixel_x = 3
-	},
-/obj/machinery/recharger/wallcharger{
-	pixel_x = 26
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/map_template/merc_shuttle/drop_pod)
-"yw" = (
-/obj/paint/sun,
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 5
-	},
-/turf/simulated/wall/titanium,
+/obj/item/storage/toolbox/syndicate,
+/obj/item/storage/toolbox/syndicate,
+/obj/item/storage/toolbox/syndicate,
+/obj/item/storage/toolbox/syndicate,
+/obj/item/rcd,
+/obj/item/rcd,
+/obj/item/rcd_ammo/large,
+/obj/item/rcd_ammo/large,
+/obj/item/gun/energy/plasmacutter,
+/obj/item/pickaxe/diamonddrill,
+/obj/item/device/paint_sprayer,
+/obj/item/storage/belt/utility,
+/obj/item/storage/belt/utility,
+/turf/simulated/floor/tiled/techfloor,
 /area/map_template/merc_shuttle)
 "yD" = (
 /obj/structure/cable{
@@ -2229,10 +2103,10 @@
 /turf/simulated/floor/tiled/white/monotile,
 /area/map_template/merc_shuttle)
 "yW" = (
-/obj/machinery/optable,
-/obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
 	},
+/obj/machinery/optable,
 /turf/simulated/floor/tiled/white/monotile,
 /area/map_template/merc_shuttle)
 "yY" = (
@@ -2253,24 +2127,18 @@
 /turf/simulated/floor/tiled/freezer,
 /area/map_template/merc_spawn)
 "zu" = (
-/obj/paint/black,
-/obj/paint_stripe/red,
-/turf/simulated/wall/r_titanium,
-/area/map_template/merc_shuttle/drop_pod)
-"zw" = (
-/obj/structure/handrail{
-	dir = 8;
-	pixel_x = 6
-	},
-/obj/floor_decal/techfloor/orange/corner{
+/obj/machinery/bodyscanner{
 	dir = 4
 	},
-/obj/floor_decal/techfloor/orange/corner{
-	dir = 1
-	},
-/obj/shuttle_landmark/merc_pod/start,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/map_template/merc_shuttle/drop_pod)
+/turf/simulated/floor/tiled/white/monotile,
+/area/map_template/merc_shuttle)
+"zw" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/fuel,
+/obj/structure/catwalk,
+/obj/machinery/light,
+/obj/machinery/pipedispenser,
+/turf/simulated/floor/tiled/techfloor,
+/area/map_template/merc_shuttle)
 "zC" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/stamp/chameleon,
@@ -2301,15 +2169,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/merc_spawn)
-"zQ" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/floor_decal/techfloor/corner{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/map_template/merc_shuttle)
 "zT" = (
 /obj/machinery/light{
 	dir = 4
@@ -2318,8 +2177,14 @@
 /turf/simulated/floor/tiled/freezer,
 /area/map_template/merc_spawn)
 "zW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 10
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/machinery/door/window/brigdoor/eastright{
+	dir = 1;
+	health_max = 150;
+	name = "The Box";
+	req_access = list("ACCESS_SYNDICATE")
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/merc_shuttle)
@@ -2334,16 +2199,10 @@
 /turf/simulated/floor/tiled/white,
 /area/map_template/merc_spawn)
 "Ak" = (
-/obj/machinery/atmospherics/binary/pump/high_power/on{
-	target_pressure = 10000
+/obj/floor_decal/industrial/warning{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/techfloor,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/map_template/merc_shuttle)
 "Am" = (
 /obj/structure/cable{
@@ -2372,25 +2231,29 @@
 /turf/simulated/wall/titanium,
 /area/map_template/merc_shuttle)
 "AO" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 10
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
 	},
-/obj/machinery/meter,
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/merc_shuttle)
 "AR" = (
+/obj/structure/handrail{
+	dir = 8
+	},
 /obj/machinery/recharger/wallcharger{
 	pixel_x = 26
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/merc_shuttle)
-"AT" = (
-/obj/machinery/door/airlock/glass,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/white,
+"AS" = (
+/obj/machinery/portable_atmospherics/canister/air/airlock{
+	start_pressure = 1900
+	},
+/obj/machinery/atmospherics/portables_connector{
+	dir = 1
+	},
+/obj/floor_decal/industrial/outline,
+/turf/simulated/floor/tiled/techfloor,
 /area/map_template/merc_shuttle)
 "AZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
@@ -2412,32 +2275,22 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/merc_shuttle)
 "Bj" = (
-/obj/structure/shuttle/engine/propulsion{
-	dir = 1
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/structure/shuttle/engine/heater{
-	dir = 1;
-	pixel_y = -32
-	},
-/turf/simulated/floor/plating,
-/area/map_template/merc_shuttle/drop_pod)
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/tiled/techfloor,
+/area/map_template/merc_shuttle)
 "Bn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /turf/simulated/floor/plating,
 /area/map_template/merc_spawn)
 "Bo" = (
 /obj/machinery/atmospherics/unary/freezer{
-	dir = 1;
-	icon_state = "freezer"
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/map_template/merc_shuttle)
-"Bq" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
-/turf/simulated/floor/tiled/techfloor,
+/turf/simulated/floor/tiled/white/monotile,
 /area/map_template/merc_shuttle)
 "Br" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -2464,13 +2317,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/map_template/merc_shuttle)
-"BG" = (
-/obj/paint/sun,
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 9
-	},
-/turf/simulated/wall/titanium,
-/area/map_template/merc_shuttle)
 "BK" = (
 /obj/floor_decal/industrial/warning/corner,
 /obj/floor_decal/industrial/warning{
@@ -2478,25 +2324,13 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/map_template/merc_shuttle)
-"BN" = (
-/obj/floor_decal/industrial/warning{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/map_template/merc_shuttle)
 "BU" = (
-/obj/floor_decal/techfloor/orange{
-	dir = 8
+/obj/machinery/atmospherics/binary/pump/high_power/on{
+	target_pressure = 10000
 	},
-/obj/floor_decal/techfloor/orange{
-	dir = 4
-	},
-/obj/machinery/door/airlock/external,
+/obj/structure/catwalk,
 /turf/simulated/floor/plating,
-/area/map_template/merc_shuttle/drop_pod)
+/area/map_template/merc_shuttle)
 "BW" = (
 /obj/shuttle_landmark/merc/nav1,
 /turf/space,
@@ -2545,22 +2379,7 @@
 /obj/floor_decal/techfloor{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
 /turf/simulated/floor/tiled/dark,
-/area/map_template/merc_shuttle)
-"CJ" = (
-/obj/paint/merc,
-/obj/wallframe_spawn/reinforced/titanium,
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
-/obj/machinery/door/blast/regular/open{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id_tag = "merc_bsa_shutters"
-	},
-/turf/simulated/floor/plating,
 /area/map_template/merc_shuttle)
 "CQ" = (
 /obj/floor_decal/industrial/outline/yellow,
@@ -2623,8 +2442,6 @@
 /obj/item/device/suit_cooling_unit,
 /obj/item/device/suit_cooling_unit,
 /obj/floor_decal/corner/blue/mono,
-/obj/item/device/suit_cooling_unit/miniature,
-/obj/item/device/suit_cooling_unit/miniature,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/map_template/merc_spawn)
 "DI" = (
@@ -2657,29 +2474,6 @@
 /obj/machinery/atmospherics/pipe/manifold4w/hidden,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/map_template/merc_spawn)
-"Ey" = (
-/obj/floor_decal/techfloor/orange/corner,
-/obj/floor_decal/techfloor/orange/corner{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/map_template/merc_shuttle/drop_pod)
-"EF" = (
-/obj/floor_decal/industrial/outline/blue,
-/obj/structure/ship_munition/disperser_charge/emp,
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/structure/railing,
-/turf/simulated/floor/tiled/dark,
-/area/map_template/merc_shuttle)
-"EK" = (
-/obj/floor_decal/industrial/outline/yellow,
-/obj/machinery/portable_atmospherics/canister/hydrogen,
-/obj/item/tank/hydrogen,
-/obj/item/tank/hydrogen,
-/turf/simulated/floor/tiled/techfloor,
-/area/map_template/merc_shuttle)
 "ER" = (
 /turf/simulated/floor/tiled/white,
 /area/map_template/merc_spawn)
@@ -2739,7 +2533,7 @@
 /obj/floor_decal/techfloor{
 	dir = 4
 	},
-/obj/machinery/computer/modular/preset/sensors/spacer{
+/obj/machinery/computer/ship/sensors/spacer{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
@@ -2834,48 +2628,19 @@
 /obj/decal/cleanable/blood/splatter,
 /turf/simulated/floor/tiled,
 /area/map_template/merc_spawn)
-"IL" = (
-/obj/structure/bed/chair/shuttle/red{
-	dir = 4
-	},
-/obj/floor_decal/techfloor/orange{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/map_template/merc_shuttle/drop_pod)
 "IO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/floor_decal/techfloor{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
 /turf/simulated/floor/tiled/dark,
 /area/map_template/merc_shuttle)
-"IR" = (
-/obj/structure/handrail{
-	dir = 4
-	},
-/obj/floor_decal/techfloor/orange{
-	dir = 4
-	},
-/obj/floor_decal/techfloor/orange{
-	dir = 8
-	},
-/obj/machinery/button/blast_door{
-	pixel_x = 23;
-	id_tag = "merc_pod1"
-	},
-/turf/simulated/floor/plating,
-/area/map_template/merc_shuttle/drop_pod)
 "Jc" = (
 /obj/wallframe_spawn/reinforced/titanium,
 /obj/machinery/door/blast/regular/open{
 	density = 0;
 	dir = 4;
-	icon_state = "pdoor0";
 	id_tag = "merc_external"
 	},
 /obj/paint/merc,
@@ -2922,24 +2687,6 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
 /area/map_template/merc_spawn)
-"Lv" = (
-/obj/paint/merc,
-/obj/machinery/vending/medical{
-	idle_power_usage = 100;
-	req_access = list("ACCESS_SYNDICATE")
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
-/turf/simulated/wall/titanium,
-/area/map_template/merc_shuttle)
-"LM" = (
-/obj/machinery/bodyscanner{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/map_template/merc_shuttle)
 "Mp" = (
 /obj/floor_decal/corner/blue/mono,
 /obj/structure/table/standard,
@@ -2965,15 +2712,6 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/map_template/merc_spawn)
-"MI" = (
-/obj/structure/bed/chair/shuttle/red{
-	dir = 8
-	},
-/obj/floor_decal/techfloor/orange{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/map_template/merc_shuttle/drop_pod)
 "MK" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating,
@@ -3063,8 +2801,9 @@
 /area/map_template/merc_shuttle)
 "Oo" = (
 /obj/paint/merc,
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 10
+/obj/machinery/vending/medical{
+	idle_power_usage = 100;
+	req_access = list("ACCESS_SYNDICATE")
 	},
 /turf/simulated/wall/titanium,
 /area/map_template/merc_shuttle)
@@ -3090,25 +2829,6 @@
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/map_template/merc_spawn)
-"OJ" = (
-/obj/wallframe_spawn/reinforced/titanium,
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
-/obj/machinery/door/blast/regular/open{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id_tag = "merc_bsa_shutters"
-	},
-/turf/simulated/floor/plating,
-/area/map_template/merc_shuttle)
-"Pv" = (
-/obj/machinery/alarm{
-	pixel_y = 24;
-	req_access = list("ACCESS_SYNDICATE")
-	},
-/obj/structure/handrail,
-/turf/simulated/floor/tiled/white,
-/area/map_template/merc_shuttle)
 "PC" = (
 /obj/random/junk,
 /obj/floor_decal/borderfloorwhite/full,
@@ -3175,25 +2895,6 @@
 /obj/floor_decal/borderfloorwhite/full,
 /turf/simulated/floor/tiled,
 /area/map_template/merc_spawn)
-"Re" = (
-/obj/floor_decal/techfloor/orange{
-	dir = 4
-	},
-/obj/floor_decal/techfloor/orange{
-	dir = 8
-	},
-/obj/machinery/door/airlock/external,
-/turf/simulated/floor/plating,
-/area/map_template/merc_shuttle/drop_pod)
-"Ry" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/map_template/merc_shuttle)
 "RH" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -3224,13 +2925,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/map_template/merc_spawn)
-"Sc" = (
-/obj/paint/merc,
-/obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
-	dir = 4
-	},
-/turf/simulated/wall/titanium,
-/area/map_template/merc_shuttle)
 "Sf" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -3248,36 +2942,15 @@
 /obj/wallframe_spawn/reinforced/titanium,
 /obj/machinery/door/blast/regular/open{
 	density = 0;
-	icon_state = "pdoor0";
 	id_tag = "merc_external"
 	},
 /obj/paint/merc,
 /turf/simulated/floor/plating,
 /area/map_template/merc_shuttle)
-"SJ" = (
-/obj/structure/bed/chair/shuttle/red{
-	dir = 8
-	},
-/obj/floor_decal/techfloor/orange{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/map_template/merc_shuttle/drop_pod)
 "SW" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled,
 /area/map_template/merc_spawn)
-"Tg" = (
-/obj/overmap/visitable/ship/landable/merc_drop_pod,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/map_template/merc_shuttle/drop_pod)
-"TC" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/white,
-/area/map_template/merc_shuttle)
 "TF" = (
 /obj/floor_decal/techfloor,
 /turf/simulated/floor/tiled/dark,
@@ -3327,24 +3000,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/map_template/merc_spawn)
-"Uq" = (
-/obj/structure/bed/chair/shuttle/red{
-	dir = 8
-	},
-/obj/floor_decal/techfloor/orange{
-	dir = 4
-	},
-/obj/machinery/light/spot{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/map_template/merc_shuttle/drop_pod)
-"UB" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/map_template/merc_shuttle)
 "UK" = (
 /obj/floor_decal/corner/blue{
 	dir = 6
@@ -3357,22 +3012,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/map_template/merc_spawn)
-"UY" = (
-/obj/floor_decal/techfloor/orange/corner{
-	dir = 4
-	},
-/obj/floor_decal/techfloor/orange/corner{
-	dir = 1
-	},
-/obj/machinery/door/blast/regular{
-	id_tag = "merc_pod1"
-	},
-/obj/machinery/button/alternate/pod_doors_explodey{
-	pixel_x = -25;
-	pixel_y = 32
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/map_template/merc_shuttle/drop_pod)
 "Vt" = (
 /obj/floor_decal/corner/blue/three_quarters{
 	dir = 4
@@ -3382,15 +3021,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/map_template/merc_spawn)
-"VH" = (
-/obj/floor_decal/industrial/outline/red,
-/obj/structure/ship_munition/disperser_charge/explosive,
-/obj/structure/railing,
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/map_template/merc_shuttle)
 "VJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -3401,30 +3031,6 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
-/area/map_template/merc_shuttle)
-"VT" = (
-/obj/structure/closet/crate{
-	dir = 1;
-	name = "reserve equipment crate"
-	},
-/obj/item/stack/material/plasteel/ten,
-/obj/item/stack/material/steel/fifty,
-/obj/item/stack/material/rods/fifty,
-/obj/item/stack/material/glass/reinforced/fifty,
-/obj/item/stack/material/glass/boron_reinforced/ten,
-/obj/item/storage/briefcase/inflatable,
-/obj/item/storage/briefcase/inflatable,
-/obj/item/inflatable_dispenser,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/floor_decal/industrial/warning{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
 /area/map_template/merc_shuttle)
 "Wr" = (
 /obj/structure/table/rack{
@@ -3438,16 +3044,14 @@
 /turf/simulated/floor/tiled,
 /area/map_template/merc_spawn)
 "WX" = (
-/obj/structure/fuel_port{
-	pixel_y = 32;
-	invisibility = 100
+/obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
+	dir = 1
 	},
-/obj/floor_decal/techfloor/orange{
-	dir = 9
+/obj/machinery/computer/ship/engines{
+	dir = 1
 	},
-/obj/machinery/computer/shuttle_control/explore/merc_shuttle/merc_drop_pod,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/map_template/merc_shuttle/drop_pod)
+/turf/simulated/floor/tiled/techfloor,
+/area/map_template/merc_shuttle)
 "WY" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -3490,16 +3094,9 @@
 /turf/simulated/floor/tiled,
 /area/map_template/merc_spawn)
 "XL" = (
-/obj/machinery/portable_atmospherics/powered/scrubber,
+/obj/structure/missile,
 /turf/simulated/floor/plating,
 /area/map_template/merc_spawn)
-"XO" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/map_template/merc_shuttle)
 "XQ" = (
 /obj/structure/hygiene/sink{
 	dir = 1;
@@ -3573,15 +3170,6 @@
 "Zl" = (
 /turf/simulated/mineral,
 /area/space)
-"Zn" = (
-/obj/structure/bed/chair/shuttle/red{
-	dir = 4
-	},
-/obj/floor_decal/techfloor/orange{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/map_template/merc_shuttle/drop_pod)
 "Zq" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -3599,13 +3187,6 @@
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/map_template/merc_spawn)
-"Zt" = (
-/obj/structure/shuttle/engine/propulsion,
-/obj/structure/shuttle/engine/heater{
-	pixel_y = 32
-	},
-/turf/simulated/floor/plating,
-/area/map_template/merc_shuttle/drop_pod)
 "ZI" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -5435,13 +5016,13 @@ AF
 AF
 AF
 AF
-AF
-AF
-AF
-AF
 cC
 cC
 cC
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -5534,16 +5115,16 @@ AF
 AF
 AF
 AF
-xc
-vC
-xc
-AF
 zC
 CQ
 Bh
 By
-bz
+wM
 AN
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -5637,15 +5218,15 @@ kW
 AF
 xt
 zW
-lS
-UB
-aw
-wM
 aw
 ax
 BK
 lz
-sx
+cC
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -5738,16 +5319,16 @@ mt
 pV
 AF
 qj
-aw
+rL
 AO
 Ak
-qQ
-ym
-Bq
-BN
 ay
-vz
+ym
 AN
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -5837,19 +5418,19 @@ hJ
 jE
 jQ
 mG
-rx
+uq
 vm
 qw
 rN
 AR
 uZ
-EK
-wS
-vH
-VT
 wG
 yR
 cC
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -5941,16 +5522,16 @@ vu
 VJ
 oT
 AF
+qy
 AF
-xp
-uE
-uE
-CJ
-uE
-uE
-Sc
-oJ
-BG
+AF
+AF
+cC
+yR
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -6042,18 +5623,18 @@ tY
 kZ
 BA
 ew
-ka
+uq
 qA
-sE
 AF
-Bj
-ut
-zu
-zu
-zu
-zu
-ut
-Zt
+xc
+vC
+xc
+yR
+cC
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -6136,7 +5717,7 @@ aa
 AF
 AF
 fa
-fa
+AF
 fa
 AF
 hL
@@ -6144,19 +5725,19 @@ zK
 ld
 ne
 CE
-Ry
-qA
-sE
+gX
+ys
+AF
 ut
-ut
-ut
+vH
+xp
 WX
-yh
-IL
-Zn
-ut
-ut
-ut
+AN
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -6236,8 +5817,8 @@ aa
 aa
 aa
 aa
-cH
-cO
+aa
+aa
 dn
 eG
 gr
@@ -6247,18 +5828,18 @@ lq
 nm
 IO
 jK
-uq
+qY
 sz
 uv
 vO
 BU
 zw
-Tg
-xq
-Ey
-Re
-IR
-UY
+cC
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -6340,7 +5921,7 @@ aa
 AF
 AF
 fa
-fa
+AF
 fa
 AF
 hU
@@ -6348,19 +5929,19 @@ TF
 lx
 nn
 CE
-Ry
+gX
 ys
-sE
-ut
-ut
-ut
+AF
+uE
+xq
+xq
 yt
-MI
-Uq
-SJ
-ut
-ut
-ut
+AN
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -6453,15 +6034,15 @@ pb
 wW
 rt
 sE
-AF
+AS
 Bj
-ut
-zu
-zu
-zu
-zu
-ut
-Zt
+oo
+yR
+cC
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -6549,20 +6130,20 @@ nI
 nI
 ia
 jR
-qy
+nI
 Qs
 pc
 AF
 rA
 Oo
-uE
-uE
-OJ
-Lv
-uE
-uE
-oJ
-yw
+AF
+AF
+cC
+yR
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -6657,15 +6238,15 @@ ph
 AF
 rB
 sH
-EF
-AF
-Pv
-xD
 uJ
 wd
 xA
 yR
 cC
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -6759,15 +6340,15 @@ pj
 AF
 rG
 sO
-XO
-AT
-oo
-TC
 uS
 xD
 xD
 yT
 AN
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -6859,17 +6440,17 @@ mj
 ob
 pt
 AF
-dY
-zQ
-rL
-vb
-LM
+zu
 sS
 xD
 xD
 xD
 yW
-sx
+cC
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -6962,16 +6543,16 @@ oc
 pH
 AF
 AF
-VH
-qY
-AF
-AF
 ta
 AZ
 Bo
 vA
 yY
 AN
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -7064,16 +6645,16 @@ oC
 mm
 mo
 AF
-AF
-AF
-AF
-AF
 Jc
 Jc
 Jc
 cC
 cC
 cC
+aa
+aa
+aa
+aa
 aa
 aa
 aa

--- a/maps/event/iccgn_ship/icgnv_hound.dmm
+++ b/maps/event/iccgn_ship/icgnv_hound.dmm
@@ -72,10 +72,6 @@
 /obj/floor_decal/techfloor{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5;
-	icon_state = "intact"
-	},
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/icgnv_hound)
 "cJ" = (
@@ -108,6 +104,14 @@
 	},
 /obj/paint/iccgn,
 /turf/simulated/floor/plating,
+/area/map_template/icgnv_hound)
+"gu" = (
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/recharger/wallcharger{
+	pixel_x = -25;
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
 /area/map_template/icgnv_hound)
 "gP" = (
 /obj/machinery/computer/ship/helm{
@@ -176,45 +180,11 @@
 	id_tag = "houndwindow";
 	name = "Window Shutters Control";
 	pixel_x = -4;
-	pixel_y = 4
+	pixel_y = 8
 	},
 /obj/structure/table/steel_reinforced,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
 /obj/floor_decal/techfloor{
 	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/map_template/icgnv_hound)
-"iK" = (
-/obj/machinery/shipsensors,
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
-/area/map_template/icgnv_hound)
-"iY" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/dark,
-/area/map_template/icgnv_hound)
-"jB" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/map_template/icgnv_hound)
-"ka" = (
-/obj/structure/table/steel_reinforced,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/floor_decal/techfloor{
-	dir = 8
 	},
 /obj/machinery/turretid/lethal{
 	ailock = 1;
@@ -225,6 +195,21 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/icgnv_hound)
+"iK" = (
+/obj/machinery/shipsensors,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
+/area/map_template/icgnv_hound)
+"ka" = (
+/obj/floor_decal/techfloor{
+	dir = 8
+	},
+/obj/machinery/computer/modular/preset/munitions/syndicate{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/map_template/icgnv_hound)
 "kg" = (
 /obj/floor_decal/techfloor{
 	dir = 4
@@ -232,16 +217,26 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/icgnv_hound)
 "ki" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
 /turf/simulated/floor/tiled/dark,
 /area/map_template/icgnv_hound)
 "kE" = (
 /obj/machinery/hologram/holopad/longrange,
 /obj/floor_decal/industrial/outline/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/map_template/icgnv_hound)
 "lg" = (
@@ -250,6 +245,9 @@
 	},
 /obj/machinery/light{
 	dir = 4
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/icgnv_hound)
@@ -295,7 +293,8 @@
 	dir = 1
 	},
 /obj/machinery/recharger/wallcharger{
-	pixel_x = -25
+	pixel_x = -25;
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/icgnv_hound)
@@ -313,8 +312,7 @@
 /area/map_template/icgnv_hound)
 "lA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 9;
-	icon_state = "intact"
+	dir = 9
 	},
 /turf/simulated/floor/tiled/dark,
 /area/map_template/icgnv_hound)
@@ -374,21 +372,8 @@
 /turf/space,
 /area/template_noop)
 "mM" = (
-/obj/structure/table/rack,
-/obj/item/device/binoculars,
-/obj/item/device/binoculars,
-/obj/item/device/binoculars,
-/obj/item/device/binoculars,
-/obj/item/device/radio/headset/iccgn,
-/obj/item/device/radio/headset/iccgn,
-/obj/item/device/radio/headset/iccgn,
-/obj/item/device/radio/headset/iccgn,
-/obj/item/crowbar/prybar,
-/obj/item/crowbar/prybar,
-/obj/item/crowbar/prybar,
-/obj/item/crowbar/prybar,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/map_template/icgnv_hound)
@@ -467,6 +452,15 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/map_template/icgnv_hound)
+"oX" = (
+/obj/machinery/door/blast/regular{
+	id_tag = "hound_pod_2_access";
+	name = "missile pod"
+	},
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
+/area/map_template/icgnv_hound)
 "pb" = (
 /obj/floor_decal/corner/blue{
 	dir = 8
@@ -489,6 +483,12 @@
 /turf/simulated/floor/plating{
 	map_airless = 1
 	},
+/area/map_template/icgnv_hound)
+"pS" = (
+/obj/machinery/door/blast/regular{
+	id_tag = "hound_pod_1"
+	},
+/turf/simulated/floor/airless,
 /area/map_template/icgnv_hound)
 "qz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal{
@@ -522,11 +522,16 @@
 	},
 /area/map_template/icgnv_hound)
 "rR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
+	},
+/obj/machinery/button/blast_door{
+	id_tag = "hound_pod_1_access";
+	name = "Missile Pod Access";
+	pixel_y = 25
 	},
 /turf/simulated/floor/plating,
 /area/map_template/icgnv_hound)
@@ -648,8 +653,7 @@
 	dir = 8
 	},
 /obj/machinery/door/airlock/centcom{
-	name = "Medical";
-	opacity = 1
+	name = "Medical"
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/map_template/icgnv_hound)
@@ -726,7 +730,6 @@
 /obj/item/storage/box/smokes,
 /obj/floor_decal/corner_techfloor_grid,
 /obj/floor_decal/techfloor/corner,
-/obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/icgnv_hound)
 "Cm" = (
@@ -738,11 +741,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/map_template/icgnv_hound)
 "Dn" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/machinery/recharger/wallcharger{
-	pixel_y = 24
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
 	},
 /turf/simulated/floor/plating,
 /area/map_template/icgnv_hound)
@@ -785,8 +785,7 @@
 /area/map_template/icgnv_hound)
 "EG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5;
-	icon_state = "intact"
+	dir = 5
 	},
 /turf/simulated/floor/tiled/dark,
 /area/map_template/icgnv_hound)
@@ -872,8 +871,7 @@
 	dir = 8
 	},
 /obj/machinery/door/airlock/centcom{
-	name = "Armory";
-	opacity = 1
+	name = "Armory"
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/map_template/icgnv_hound)
@@ -940,6 +938,13 @@
 	name = "External Blast Shield"
 	},
 /obj/paint/iccgn,
+/turf/simulated/floor/plating,
+/area/map_template/icgnv_hound)
+"Ip" = (
+/obj/machinery/door/blast/regular{
+	id_tag = "hound_pod_1_access";
+	name = "missile pod"
+	},
 /turf/simulated/floor/plating,
 /area/map_template/icgnv_hound)
 "IF" = (
@@ -1058,8 +1063,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 9;
-	icon_state = "intact"
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
@@ -1068,6 +1072,11 @@
 "Mk" = (
 /obj/floor_decal/techfloor,
 /obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/button/blast_door{
+	id_tag = "hound_pod_2_access";
+	name = "Missile Pod Access";
+	pixel_y = 25
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/icgnv_hound)
 "Mq" = (
@@ -1146,6 +1155,27 @@
 	},
 /turf/simulated/floor/plating,
 /area/map_template/icgnv_hound)
+"Os" = (
+/obj/structure/table/rack,
+/obj/item/device/binoculars,
+/obj/item/device/binoculars,
+/obj/item/device/binoculars,
+/obj/item/device/binoculars,
+/obj/item/device/radio/headset/iccgn,
+/obj/item/device/radio/headset/iccgn,
+/obj/item/device/radio/headset/iccgn,
+/obj/item/device/radio/headset/iccgn,
+/obj/item/crowbar/prybar,
+/obj/item/crowbar/prybar,
+/obj/item/crowbar/prybar,
+/obj/item/crowbar/prybar,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/recharger/wallcharger{
+	pixel_x = 25;
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/map_template/icgnv_hound)
 "OI" = (
 /obj/floor_decal/techfloor,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
@@ -1177,12 +1207,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 10
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/floor_decal/techfloor/corner{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 6
 	},
 /turf/simulated/floor/tiled/dark,
 /area/map_template/icgnv_hound)
@@ -1234,8 +1264,7 @@
 	dir = 8
 	},
 /obj/machinery/door/airlock/centcom{
-	name = "Shields & Power";
-	opacity = 1
+	name = "Shields & Power"
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/map_template/icgnv_hound)
@@ -1285,6 +1314,17 @@
 	name = "External Blast Shield"
 	},
 /turf/simulated/floor/tiled/dark,
+/area/map_template/icgnv_hound)
+"Su" = (
+/obj/machinery/payload_interface{
+	name = "Missile Pod 1";
+	id_tag = "hound_pod_1";
+	allow_arming = 1
+	},
+/obj/structure/missile/he{
+	dir = 1
+	},
+/turf/simulated/floor/airless,
 /area/map_template/icgnv_hound)
 "SR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
@@ -1467,6 +1507,17 @@
 /obj/machinery/door/airlock/centcom,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/map_template/icgnv_hound)
+"VM" = (
+/obj/machinery/payload_interface{
+	name = "Missile Pod 2";
+	id_tag = "hound_pod_2";
+	allow_arming = 1
+	},
+/obj/structure/missile/antispace{
+	dir = 1
+	},
+/turf/simulated/floor/airless,
+/area/map_template/icgnv_hound)
 "VZ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 4
@@ -1478,6 +1529,12 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
+/area/map_template/icgnv_hound)
+"Ww" = (
+/obj/machinery/door/blast/regular{
+	id_tag = "hound_pod_2"
+	},
+/turf/simulated/floor/airless,
 /area/map_template/icgnv_hound)
 "Wz" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
@@ -1499,9 +1556,7 @@
 /area/map_template/icgnv_hound)
 "WO" = (
 /obj/floor_decal/techfloor,
-/obj/machinery/recharger/wallcharger{
-	pixel_y = 24
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/icgnv_hound)
 "WX" = (
@@ -1522,6 +1577,9 @@
 	dir = 4
 	},
 /obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 9
+	},
 /turf/simulated/floor/tiled/dark,
 /area/map_template/icgnv_hound)
 "XA" = (
@@ -1661,10 +1719,10 @@ av
 av
 av
 av
-av
 Zx
 mK
-PQ
+iK
+cc
 os
 rs
 nT
@@ -1686,9 +1744,9 @@ av
 av
 av
 av
-av
-PQ
-fM
+rv
+oF
+Os
 Dn
 qz
 fM
@@ -1709,9 +1767,9 @@ av
 av
 av
 av
-av
-iK
-cc
+PQ
+PQ
+fM
 rR
 dq
 DM
@@ -1732,9 +1790,9 @@ av
 av
 av
 av
-av
-rv
-oF
+pS
+Su
+Ip
 mM
 Ol
 fM
@@ -1799,7 +1857,7 @@ av
 cc
 cj
 gZ
-iY
+Cu
 ki
 lt
 mT
@@ -1822,7 +1880,7 @@ Cm
 cc
 cJ
 gZ
-jB
+Cu
 kE
 mh
 fM
@@ -1893,9 +1951,9 @@ av
 av
 av
 av
-av
-ar
-bX
+Ww
+VM
+oX
 Cc
 cF
 fM
@@ -1916,9 +1974,9 @@ av
 av
 av
 av
-av
-pq
-cc
+PQ
+PQ
+fM
 Mk
 OR
 FQ
@@ -1939,9 +1997,9 @@ av
 av
 av
 av
-av
-PQ
-PQ
+ar
+bX
+gu
 WO
 Xd
 fM
@@ -1960,10 +2018,10 @@ av
 av
 av
 av
-av
 Zx
 mK
-PQ
+pq
+cc
 if
 OI
 UZ

--- a/maps/event/sfv_arbiter/sfv_arbiter.dmm
+++ b/maps/event/sfv_arbiter/sfv_arbiter.dmm
@@ -2,8 +2,7 @@
 "al" = (
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -17,11 +16,6 @@
 "au" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 32
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /obj/floor_decal/corner/grey{
 	dir = 1
@@ -77,13 +71,11 @@
 	dir = 4
 	},
 /obj/floor_decal/corner/red{
-	dir = 9;
-	icon_state = "corner_white"
+	dir = 9
 	},
 /obj/machinery/light{
 	dir = 8;
-	icon_state = "tube1";
-	pixel_y = 0
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/map_template/sfv_arbiter)
@@ -110,7 +102,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/wallframe_spawn/reinforced/polarized{
+/obj/wallframe_spawn/reinforced/polarized/full{
 	color = "#4c535b"
 	},
 /obj/paint/iccgn,
@@ -135,21 +127,9 @@
 "dv" = (
 /obj/structure/closet/secure_closet/chemical,
 /obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 2;
 	level = 2
 	},
 /turf/simulated/floor/tiled/white,
-/area/map_template/sfv_arbiter)
-"dR" = (
-/obj/structure/bed/chair/shuttle/black{
-	dir = 8
-	},
-/obj/floor_decal/corner/grey/mono,
-/obj/item/clothing/head/helmet,
-/obj/item/modular_computer/telescreen/preset/navigation{
-	pixel_x = 32
-	},
-/turf/simulated/floor/tiled/dark/monotile,
 /area/map_template/sfv_arbiter)
 "et" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -173,10 +153,7 @@
 	dir = 4
 	},
 /obj/structure/table/glass,
-/obj/item/reagent_containers/glass/beaker/cryoxadone{
-	pixel_x = 0;
-	pixel_y = 0
-	},
+/obj/item/reagent_containers/glass/beaker/cryoxadone,
 /turf/simulated/floor/tiled/white,
 /area/map_template/sfv_arbiter)
 "gS" = (
@@ -209,8 +186,7 @@
 /area/map_template/sfv_arbiter)
 "it" = (
 /obj/floor_decal/industrial/warning{
-	dir = 1;
-	icon_state = "stripe"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -226,8 +202,7 @@
 /obj/structure/closet/crate/radiation,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/floor_decal/industrial/warning{
-	dir = 1;
-	icon_state = "stripe"
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/map_template/sfv_arbiter)
@@ -243,15 +218,13 @@
 /area/map_template/sfv_arbiter)
 "jM" = (
 /obj/floor_decal/corner/red{
-	dir = 4;
-	icon_state = "corner_white"
+	dir = 4
 	},
 /obj/structure/bed/chair/shuttle/black{
 	dir = 4
 	},
 /obj/floor_decal/corner/red{
-	dir = 9;
-	icon_state = "corner_white"
+	dir = 9
 	},
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -303,11 +276,6 @@
 	},
 /obj/floor_decal/industrial/warning{
 	dir = 8
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -441,8 +409,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 9;
-	icon_state = "intact"
+	dir = 9
 	},
 /turf/simulated/floor/tiled/white,
 /area/map_template/sfv_arbiter)
@@ -461,11 +428,6 @@
 "od" = (
 /obj/floor_decal/corner/grey{
 	dir = 5
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/map_template/sfv_arbiter)
@@ -515,15 +477,13 @@
 /area/map_template/sfv_arbiter)
 "qn" = (
 /obj/machinery/bodyscanner{
-	dir = 4;
-	icon_state = "body_scanner_0"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/map_template/sfv_arbiter)
 "qq" = (
 /obj/structure/table/steel_reinforced,
 /obj/machinery/button/blast_door{
-	icon_state = "doorctrl0";
 	id_tag = "rescuebridge";
 	name = "Window Shutters Control";
 	pixel_x = 4
@@ -534,7 +494,7 @@
 /area/map_template/sfv_arbiter)
 "qt" = (
 /obj/paint/black,
-/obj/machinery/vending/medical,
+/obj/machinery/vending/medical/torch,
 /turf/simulated/wall/titanium,
 /area/map_template/sfv_arbiter)
 "qv" = (
@@ -577,17 +537,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/map_template/sfv_arbiter)
 "qP" = (
-/obj/structure/bed/chair/shuttle/black{
-	dir = 4
-	},
 /obj/floor_decal/corner/grey/mono,
-/obj/item/clothing/head/helmet,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_x = -32
 	},
-/turf/simulated/floor/tiled/dark/monotile,
+/obj/structure/bed/chair/shuttle/black,
+/obj/item/clothing/head/helmet,
+/turf/simulated/floor/plating,
 /area/map_template/sfv_arbiter)
 "sH" = (
 /obj/structure/catwalk,
@@ -628,8 +584,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/floor_decal/corner/yellow/full,
 /obj/machinery/door/airlock/centcom{
-	name = "Armory";
-	opacity = 1
+	name = "Armory"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/map_template/sfv_arbiter)
@@ -677,7 +632,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/wallframe_spawn/reinforced/polarized{
+/obj/wallframe_spawn/reinforced/polarized/full{
 	color = "#4c535b"
 	},
 /obj/paint/iccgn,
@@ -763,7 +718,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/wallframe_spawn/reinforced/polarized{
+/obj/wallframe_spawn/reinforced/polarized/full{
 	color = "#4c535b"
 	},
 /obj/paint/iccgn,
@@ -773,8 +728,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/floor_decal/corner/yellow{
-	dir = 5;
-	icon_state = "corner_white"
+	dir = 5
 	},
 /turf/simulated/floor/tiled,
 /area/map_template/sfv_arbiter)
@@ -871,7 +825,7 @@
 /turf/simulated/floor/tiled,
 /area/map_template/sfv_arbiter)
 "zZ" = (
-/obj/machinery/computer/modular/preset/sensors,
+/obj/machinery/computer/ship/sensors,
 /obj/floor_decal/corner/blue/mono,
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -900,7 +854,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/map_template/sfv_arbiter)
 "Bb" = (
-/obj/machinery/computer/modular/preset/helm,
+/obj/machinery/computer/ship/engines,
 /obj/floor_decal/corner/blue/mono,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/map_template/sfv_arbiter)
@@ -917,8 +871,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 9;
-	icon_state = "intact"
+	dir = 9
 	},
 /turf/simulated/floor/tiled/dark,
 /area/map_template/sfv_arbiter)
@@ -961,11 +914,6 @@
 /obj/floor_decal/industrial/warning/corner{
 	dir = 8
 	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/tiled/dark,
 /area/map_template/sfv_arbiter)
 "Cj" = (
@@ -983,8 +931,7 @@
 	},
 /obj/machinery/light{
 	dir = 8;
-	icon_state = "tube1";
-	pixel_y = 0
+	icon_state = "tube1"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled/techfloor,
@@ -1011,23 +958,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
-/area/map_template/sfv_arbiter)
-"DI" = (
-/obj/wallframe_spawn/reinforced/titanium,
-/obj/structure/cable/cyan{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/door/blast/regular/escape_pod{
-	id_tag = "rescuedock";
-	name = "External Blast Shield"
-	},
-/obj/paint/iccgn,
-/obj/structure/cable/cyan{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/plating,
 /area/map_template/sfv_arbiter)
 "DK" = (
 /obj/floor_decal/corner/blue{
@@ -1058,8 +988,7 @@
 /area/map_template/sfv_arbiter)
 "Eh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 9;
-	icon_state = "intact"
+	dir = 9
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/map_template/sfv_arbiter)
@@ -1107,7 +1036,7 @@
 	dir = 1;
 	icon_state = "0-2"
 	},
-/obj/wallframe_spawn/reinforced/polarized{
+/obj/wallframe_spawn/reinforced/polarized/full{
 	color = "#4c535b"
 	},
 /obj/paint/iccgn,
@@ -1127,27 +1056,6 @@
 	pixel_y = 24
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/map_template/sfv_arbiter)
-"EU" = (
-/obj/structure/bed/chair/shuttle/black{
-	dir = 4
-	},
-/obj/floor_decal/corner/grey/mono,
-/obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_y = 0
-	},
-/obj/item/clothing/head/helmet,
-/obj/item/modular_computer/telescreen/preset/navigation{
-	pixel_x = -32
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/dark/monotile,
 /area/map_template/sfv_arbiter)
 "EW" = (
 /obj/machinery/vitals_monitor,
@@ -1208,15 +1116,13 @@
 	icon_state = "warning"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 9;
-	icon_state = "intact"
+	dir = 9
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/sfv_arbiter)
 "HR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5;
-	icon_state = "intact"
+	dir = 5
 	},
 /obj/shuttle_landmark/sfv_arbiter/start,
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -1254,8 +1160,7 @@
 "Is" = (
 /obj/floor_decal/corner/b_green/full,
 /obj/machinery/door/airlock/centcom{
-	name = "EVA";
-	opacity = 1
+	name = "EVA"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -1274,8 +1179,7 @@
 "IH" = (
 /obj/machinery/light{
 	dir = 8;
-	icon_state = "tube1";
-	pixel_y = 0
+	icon_state = "tube1"
 	},
 /obj/floor_decal/industrial/warning/corner{
 	dir = 1
@@ -1366,24 +1270,6 @@
 /obj/structure/window/boron_reinforced{
 	dir = 1
 	},
-/turf/simulated/floor/plating,
-/area/map_template/sfv_arbiter)
-"KK" = (
-/obj/wallframe_spawn/reinforced/titanium,
-/obj/structure/cable/cyan{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/structure/cable/cyan{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/door/blast/regular/escape_pod{
-	id_tag = "rescuedock";
-	name = "External Blast Shield"
-	},
-/obj/paint/iccgn,
-/obj/paint/iccgn,
 /turf/simulated/floor/plating,
 /area/map_template/sfv_arbiter)
 "KO" = (
@@ -1535,8 +1421,7 @@
 	dir = 10
 	},
 /obj/floor_decal/corner/b_green{
-	dir = 5;
-	icon_state = "corner_white"
+	dir = 5
 	},
 /obj/structure/cable/cyan{
 	d1 = 2;
@@ -1548,8 +1433,7 @@
 "Mx" = (
 /obj/paint/black,
 /obj/structure/sign/warning/high_voltage{
-	dir = 8;
-	icon_state = "shock"
+	dir = 8
 	},
 /turf/simulated/wall/titanium,
 /area/map_template/sfv_arbiter)
@@ -1571,16 +1455,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/map_template/sfv_arbiter)
 "Nf" = (
-/obj/structure/table/steel_reinforced,
-/obj/machinery/button/blast_door{
-	icon_state = "doorctrl0";
-	id_tag = "rescuebridge";
-	name = "Window Shutters Control";
-	pixel_x = -4;
-	pixel_y = 4
-	},
 /obj/floor_decal/corner/blue/mono,
-/obj/item/device/radio/headset/sfv_arbiter,
+/obj/machinery/computer/modular/preset/munitions/syndicate{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/map_template/sfv_arbiter)
 "Nh" = (
@@ -1644,17 +1522,10 @@
 /turf/simulated/floor/tiled,
 /area/map_template/sfv_arbiter)
 "NO" = (
-/obj/wallframe_spawn/reinforced/titanium,
-/obj/structure/cable/cyan{
-	d2 = 8;
-	icon_state = "0-8"
+/obj/machinery/door/blast/regular{
+	id_tag = "arbiter_pod_3"
 	},
-/obj/machinery/door/blast/regular/escape_pod{
-	id_tag = "rescuedock";
-	name = "External Blast Shield"
-	},
-/obj/paint/iccgn,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/airless,
 /area/map_template/sfv_arbiter)
 "NV" = (
 /obj/structure/cable/cyan{
@@ -1717,8 +1588,7 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/centcom{
-	name = "Shields & Power";
-	opacity = 1
+	name = "Shields & Power"
 	},
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -1755,8 +1625,7 @@
 	},
 /obj/item/device/radio/intercom/specops{
 	dir = 8;
-	pixel_x = 22;
-	pixel_y = 0
+	pixel_x = 22
 	},
 /turf/simulated/floor/tiled/dark,
 /area/map_template/sfv_arbiter)
@@ -1782,8 +1651,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/airlock/centcom{
-	name = "Holding Area";
-	opacity = 1
+	name = "Holding Area"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/map_template/sfv_arbiter)
@@ -1792,8 +1660,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/floor_decal/corner/white/full,
 /obj/machinery/door/airlock/centcom{
-	name = "Medical";
-	opacity = 1
+	name = "Medical"
 	},
 /turf/simulated/floor/tiled/white,
 /area/map_template/sfv_arbiter)
@@ -1841,21 +1708,10 @@
 /turf/simulated/floor/plating,
 /area/map_template/sfv_arbiter)
 "QF" = (
-/obj/wallframe_spawn/reinforced/titanium,
-/obj/structure/cable/cyan{
-	d2 = 8;
-	icon_state = "0-8"
+/obj/machinery/door/blast/regular{
+	id_tag = "arbiter_pod_2"
 	},
-/obj/structure/cable/cyan{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/door/blast/regular/escape_pod{
-	id_tag = "rescuedock";
-	name = "External Blast Shield"
-	},
-/obj/paint/iccgn,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/airless,
 /area/map_template/sfv_arbiter)
 "QG" = (
 /obj/structure/catwalk,
@@ -1876,8 +1732,7 @@
 /area/map_template/sfv_arbiter)
 "QQ" = (
 /obj/floor_decal/industrial/warning{
-	dir = 1;
-	icon_state = "stripe"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -1921,12 +1776,19 @@
 "RK" = (
 /obj/floor_decal/corner/blue/mono,
 /obj/machinery/light/spot,
+/obj/structure/table/steel_reinforced,
+/obj/machinery/button/blast_door{
+	id_tag = "rescuebridge";
+	name = "Window Shutters Control";
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/item/device/radio/headset/sfv_arbiter,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/map_template/sfv_arbiter)
 "RM" = (
 /obj/floor_decal/corner/blue{
-	dir = 8;
-	icon_state = "corner_white"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/map_template/sfv_arbiter)
@@ -1987,8 +1849,7 @@
 /area/map_template/sfv_arbiter)
 "Sy" = (
 /obj/floor_decal/corner/red{
-	dir = 1;
-	icon_state = "corner_white"
+	dir = 1
 	},
 /obj/floor_decal/corner/red{
 	dir = 6
@@ -2051,22 +1912,10 @@
 /obj/floor_decal/industrial/warning/corner,
 /turf/simulated/floor/tiled/dark,
 /area/map_template/sfv_arbiter)
-"TZ" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/floor_decal/corner/grey{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/dark,
-/area/map_template/sfv_arbiter)
 "Ue" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/floor_decal/corner/yellow{
-	dir = 10;
-	icon_state = "corner_white"
+	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
@@ -2084,7 +1933,6 @@
 /obj/structure/iv_stand,
 /obj/structure/closet/secure_closet/medical_wall{
 	name = "IV Equipment Cabinet";
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/item/reagent_containers/ivbag/nanoblood,
@@ -2228,17 +2076,6 @@
 	map_airless = 1
 	},
 /area/map_template/sfv_arbiter)
-"VT" = (
-/obj/floor_decal/corner/grey{
-	dir = 5
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/map_template/sfv_arbiter)
 "VU" = (
 /obj/floor_decal/industrial/warning/corner,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -2275,7 +2112,6 @@
 	id_tag = "sfv_arbiter_shuttle_pump"
 	},
 /obj/machinery/button/blast_door{
-	icon_state = "doorctrl0";
 	id_tag = "rescuedock";
 	name = "Window Shutters Control";
 	pixel_x = 24;
@@ -2324,10 +2160,15 @@
 /turf/simulated/wall/titanium,
 /area/map_template/sfv_arbiter)
 "WW" = (
-/obj/floor_decal/corner/grey{
-	dir = 9
+/obj/machinery/payload_interface{
+	name = "Missile Pod 2";
+	id_tag = "arbiter_pod_2";
+	allow_arming = 1
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/structure/missile/he{
+	dir = 1
+	},
+/turf/simulated/floor/airless,
 /area/map_template/sfv_arbiter)
 "Xa" = (
 /obj/structure/catwalk,
@@ -2337,12 +2178,6 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
-/area/map_template/sfv_arbiter)
-"Xd" = (
-/obj/floor_decal/corner/grey{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/dark,
 /area/map_template/sfv_arbiter)
 "Xl" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -2437,28 +2272,34 @@
 /area/map_template/sfv_arbiter)
 "XU" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 5;
-	icon_state = "intact"
+	dir = 5
 	},
 /turf/simulated/floor/tiled/white,
 /area/map_template/sfv_arbiter)
 "Yb" = (
-/obj/floor_decal/corner/grey/three_quarters,
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/door/blast/regular{
+	id_tag = "arbiter_pod_1"
+	},
+/turf/simulated/floor/airless,
 /area/map_template/sfv_arbiter)
 "Yl" = (
-/obj/floor_decal/corner/grey/three_quarters{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
+/obj/floor_decal/corner/grey/mono,
+/obj/structure/bed/chair/shuttle/black,
+/obj/item/clothing/head/helmet,
+/turf/simulated/floor/plating,
 /area/map_template/sfv_arbiter)
 "Yn" = (
-/obj/structure/bed/chair/shuttle/black{
-	dir = 8
-	},
 /obj/floor_decal/corner/grey/mono,
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_x = 32
+	},
+/obj/structure/bed/chair/shuttle/black,
 /obj/item/clothing/head/helmet,
-/turf/simulated/floor/tiled/dark/monotile,
+/obj/item/flame/lighter/zippo/gunmetal{
+	pixel_x = 5
+	},
+/obj/item/storage/fancy/smokable/transstellar,
+/turf/simulated/floor/plating,
 /area/map_template/sfv_arbiter)
 "YA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -2495,28 +2336,18 @@
 /area/map_template/sfv_arbiter)
 "YN" = (
 /obj/floor_decal/corner/grey/mono,
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/plating,
 /area/map_template/sfv_arbiter)
 "YR" = (
 /obj/floor_decal/corner/grey/mono,
-/obj/structure/reagent_dispensers/water_cooler{
-	dir = 8;
-	icon_state = "water_cooler"
-	},
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/plating,
 /area/map_template/sfv_arbiter)
 "YT" = (
 /obj/floor_decal/corner/white{
-	dir = 4;
-	icon_state = "corner_white"
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/map_template/sfv_arbiter)
@@ -2527,7 +2358,6 @@
 	icon_state = "1-2"
 	},
 /obj/floor_decal/industrial/warning/corner{
-	dir = 2;
 	icon_state = "warningcorner"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -2536,25 +2366,15 @@
 /turf/simulated/floor/tiled/dark,
 /area/map_template/sfv_arbiter)
 "Zf" = (
-/obj/machinery/button/blast_door{
-	icon_state = "doorctrl0";
-	id_tag = "rescuedock";
-	name = "Window Shutters Control";
-	pixel_x = -24;
-	pixel_y = -4
+/obj/machinery/payload_interface{
+	name = "Missile Pod 3";
+	id_tag = "arbiter_pod_3";
+	allow_arming = 1
 	},
-/obj/floor_decal/corner/grey/mono,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/missile/antispace{
+	dir = 1
 	},
-/obj/structure/table/steel_reinforced,
-/obj/item/flame/lighter/zippo/gunmetal{
-	pixel_x = 5
-	},
-/obj/item/storage/fancy/smokable/transstellar,
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/airless,
 /area/map_template/sfv_arbiter)
 "Zj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -2562,17 +2382,11 @@
 /obj/floor_decal/corner/white{
 	dir = 5
 	},
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /turf/simulated/floor/tiled/dark,
 /area/map_template/sfv_arbiter)
 "Zk" = (
 /obj/floor_decal/corner/white{
-	dir = 1;
-	icon_state = "corner_white"
+	dir = 1
 	},
 /obj/structure/sign/warning/nosmoking_1{
 	pixel_y = 23
@@ -2593,15 +2407,20 @@
 	},
 /obj/floor_decal/corner/blue/full,
 /obj/machinery/door/airlock/centcom{
-	name = "Bridge";
-	opacity = 1
+	name = "Bridge"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/map_template/sfv_arbiter)
 "Zu" = (
-/obj/paint/black,
-/obj/paint/iccgn,
-/turf/simulated/wall/r_titanium,
+/obj/machinery/payload_interface{
+	name = "Missile Pod 1";
+	id_tag = "arbiter_pod_1";
+	allow_arming = 1
+	},
+/obj/structure/missile/he{
+	dir = 1
+	},
+/turf/simulated/floor/airless,
 /area/map_template/sfv_arbiter)
 "Zv" = (
 /obj/floor_decal/corner/yellow{
@@ -2799,12 +2618,12 @@ VG
 et
 XO
 aq
-XH
+sS
 XH
 "}
 (10,1,1) = {"
 XH
-XH
+aq
 aq
 aq
 LU
@@ -2818,12 +2637,12 @@ VJ
 BE
 WV
 aq
-sS
+aq
 XH
 "}
 (11,1,1) = {"
 XH
-aq
+Yb
 Zu
 WV
 WV
@@ -2836,18 +2655,18 @@ WV
 WV
 WV
 WV
-aq
+WV
 aq
 gS
 "}
 (12,1,1) = {"
 XH
-DI
-Zf
-EU
+aq
+aq
+WV
 qP
-qP
-VT
+YN
+od
 IU
 SK
 al
@@ -2863,8 +2682,8 @@ XH
 XH
 QF
 WW
-WW
-Yb
+WV
+Yl
 YN
 od
 VU
@@ -2880,12 +2699,12 @@ XH
 "}
 (14,1,1) = {"
 Pp
-KK
-Xd
-Xd
+aq
+aq
+WV
 Yl
 YN
-TZ
+od
 FJ
 yb
 it
@@ -2900,11 +2719,11 @@ XH
 (15,1,1) = {"
 XH
 NO
-Yn
-dR
+Zf
+WV
 Yn
 YR
-TZ
+od
 Nh
 NV
 QS

--- a/maps/event/sfv_arbiter/sfv_arbiter.dmm
+++ b/maps/event/sfv_arbiter/sfv_arbiter.dmm
@@ -102,7 +102,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/wallframe_spawn/reinforced/polarized/full{
+/obj/wallframe_spawn/reinforced/polarized{
 	color = "#4c535b"
 	},
 /obj/paint/iccgn,
@@ -538,7 +538,7 @@
 /area/map_template/sfv_arbiter)
 "qP" = (
 /obj/floor_decal/corner/grey/mono,
-/obj/machinery/computer/ship/navigation/telescreen{
+/obj/item/modular_computer/telescreen/preset/navigation{
 	pixel_x = -32
 	},
 /obj/structure/bed/chair/shuttle/black,
@@ -632,7 +632,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/wallframe_spawn/reinforced/polarized/full{
+/obj/wallframe_spawn/reinforced/polarized{
 	color = "#4c535b"
 	},
 /obj/paint/iccgn,
@@ -718,7 +718,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/wallframe_spawn/reinforced/polarized/full{
+/obj/wallframe_spawn/reinforced/polarized{
 	color = "#4c535b"
 	},
 /obj/paint/iccgn,
@@ -825,7 +825,7 @@
 /turf/simulated/floor/tiled,
 /area/map_template/sfv_arbiter)
 "zZ" = (
-/obj/machinery/computer/ship/sensors,
+/obj/machinery/computer/modular/preset/sensors,
 /obj/floor_decal/corner/blue/mono,
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -854,7 +854,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/map_template/sfv_arbiter)
 "Bb" = (
-/obj/machinery/computer/ship/engines,
+/obj/machinery/computer/modular/preset/helm,
 /obj/floor_decal/corner/blue/mono,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/map_template/sfv_arbiter)
@@ -1036,7 +1036,7 @@
 	dir = 1;
 	icon_state = "0-2"
 	},
-/obj/wallframe_spawn/reinforced/polarized/full{
+/obj/wallframe_spawn/reinforced/polarized{
 	color = "#4c535b"
 	},
 /obj/paint/iccgn,
@@ -2290,7 +2290,7 @@
 /area/map_template/sfv_arbiter)
 "Yn" = (
 /obj/floor_decal/corner/grey/mono,
-/obj/machinery/computer/ship/navigation/telescreen{
+/obj/item/modular_computer/telescreen/preset/navigation{
 	pixel_x = 32
 	},
 /obj/structure/bed/chair/shuttle/black,

--- a/mods/_maps/general_maps/maps/icgnv_hound.dmm
+++ b/mods/_maps/general_maps/maps/icgnv_hound.dmm
@@ -24,6 +24,14 @@
 /obj/floor_decal/techfloor,
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/icgnv_hound)
+"cy" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
+	id_tag = "merc_shuttle_pump_out_external"
+	},
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
+/area/template_noop)
 "cJ" = (
 /obj/machinery/computer/modular/preset/helm,
 /obj/floor_decal/techfloor,
@@ -94,6 +102,12 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/map_template/icgnv_hound)
+"hv" = (
+/obj/machinery/door/blast/regular{
+	id_tag = "hound_pod_2"
+	},
+/turf/simulated/floor/airless,
+/area/template_noop)
 "hV" = (
 /obj/machinery/computer/modular/preset/sensors{
 	dir = 8
@@ -112,26 +126,33 @@
 	id_tag = "houndwindow";
 	name = "Window Shutters Control";
 	pixel_x = -4;
-	pixel_y = 4
+	pixel_y = 8
 	},
 /obj/structure/table/steel_reinforced,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
 /obj/floor_decal/techfloor{
 	dir = 4
+	},
+/obj/machinery/turretid/lethal{
+	ailock = 1;
+	check_arrest = 0;
+	check_records = 0;
+	enabled = 0;
+	req_access = list("ACCESS_SYNDICATE")
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/icgnv_hound)
 "iY" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	controlled = 0;
+	icon_state = "map_vent_in";
+	pressure_checks = 2;
+	pressure_checks_default = 2;
+	use_power = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+/turf/simulated/floor/plating{
+	map_airless = 1
 	},
-/turf/simulated/floor/tiled/dark,
-/area/map_template/icgnv_hound)
+/area/template_noop)
 "je" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -148,11 +169,10 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/map_template/icgnv_hound)
 "jB" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/turf/simulated/floor/plating{
+	map_airless = 1
 	},
-/turf/simulated/floor/tiled/dark,
-/area/map_template/icgnv_hound)
+/area/template_noop)
 "jS" = (
 /obj/floor_decal/techfloor{
 	dir = 10
@@ -160,19 +180,11 @@
 /turf/simulated/floor/tiled,
 /area/map_template/icgnv_hound)
 "ka" = (
-/obj/structure/table/steel_reinforced,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
 /obj/floor_decal/techfloor{
 	dir = 8
 	},
-/obj/machinery/turretid/lethal{
-	ailock = 1;
-	check_arrest = 0;
-	check_records = 0;
-	enabled = 0;
-	req_access = list("ACCESS_SYNDICATE")
+/obj/machinery/computer/modular/preset/munitions/syndicate{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/icgnv_hound)
@@ -183,16 +195,32 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/icgnv_hound)
+"kh" = (
+/obj/machinery/door/blast/regular{
+	id_tag = "hound_pod_1"
+	},
+/turf/simulated/floor/airless,
+/area/template_noop)
 "ki" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
 /turf/simulated/floor/tiled/dark,
 /area/map_template/icgnv_hound)
 "kE" = (
 /obj/machinery/hologram/holopad/longrange,
 /obj/floor_decal/industrial/outline/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/map_template/icgnv_hound)
 "kH" = (
@@ -219,6 +247,9 @@
 	},
 /obj/machinery/light{
 	dir = 4
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/icgnv_hound)
@@ -255,7 +286,8 @@
 	dir = 1
 	},
 /obj/machinery/recharger/wallcharger{
-	pixel_x = -25
+	pixel_x = -25;
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/icgnv_hound)
@@ -273,8 +305,7 @@
 /area/map_template/icgnv_hound)
 "lA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 9;
-	icon_state = "intact"
+	dir = 9
 	},
 /turf/simulated/floor/tiled/dark,
 /area/map_template/icgnv_hound)
@@ -305,22 +336,19 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/icgnv_hound)
 "mA" = (
-/obj/machinery/shipsensors,
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
-/area/map_template/icgnv_hound)
+/obj/paint/iccgn,
+/turf/simulated/wall/r_titanium,
+/area/template_noop)
 "mK" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	controlled = 0;
-	icon_state = "map_vent_in";
-	pressure_checks = 2;
-	pressure_checks_default = 2;
-	use_power = 1
+/obj/machinery/payload_interface{
+	name = "Missile Pod 1";
+	id_tag = "hound_pod_1";
+	allow_arming = 1
 	},
-/turf/simulated/floor/plating{
-	map_airless = 1
+/obj/structure/missile/he{
+	dir = 1
 	},
+/turf/simulated/floor/airless,
 /area/map_template/icgnv_hound)
 "mT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -335,12 +363,15 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/map_template/icgnv_hound)
 "nz" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
-	id_tag = "merc_shuttle_pump_out_external"
+/obj/machinery/payload_interface{
+	name = "Missile Pod 2";
+	id_tag = "hound_pod_2";
+	allow_arming = 1
 	},
-/turf/simulated/floor/plating{
-	map_airless = 1
+/obj/structure/missile/antispace{
+	dir = 1
 	},
+/turf/simulated/floor/airless,
 /area/map_template/icgnv_hound)
 "nT" = (
 /obj/machinery/portable_atmospherics/canister/air,
@@ -461,30 +492,22 @@
 /turf/simulated/floor/plating,
 /area/map_template/icgnv_hound)
 "rv" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
+	},
+/obj/machinery/button/blast_door{
+	id_tag = "hound_pod_1_access";
+	name = "Missile Pod Access";
+	pixel_y = 25
 	},
 /turf/simulated/floor/plating,
 /area/map_template/icgnv_hound)
 "rR" = (
-/obj/structure/table/rack,
-/obj/item/device/binoculars,
-/obj/item/device/binoculars,
-/obj/item/device/binoculars,
-/obj/item/device/binoculars,
-/obj/item/device/radio/headset/iccgn,
-/obj/item/device/radio/headset/iccgn,
-/obj/item/device/radio/headset/iccgn,
-/obj/item/device/radio/headset/iccgn,
-/obj/item/crowbar/prybar,
-/obj/item/crowbar/prybar,
-/obj/item/crowbar/prybar,
-/obj/item/crowbar/prybar,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/map_template/icgnv_hound)
@@ -549,12 +572,16 @@
 /obj/item/storage/box/smokes,
 /obj/floor_decal/corner_techfloor_grid,
 /obj/floor_decal/techfloor/corner,
-/obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/icgnv_hound)
 "vw" = (
 /obj/floor_decal/techfloor,
 /obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/button/blast_door{
+	id_tag = "hound_pod_2_access";
+	name = "Missile Pod Access";
+	pixel_y = 25
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/icgnv_hound)
 "vE" = (
@@ -602,6 +629,27 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/map_template/icgnv_hound)
+"xn" = (
+/obj/structure/table/rack,
+/obj/item/device/binoculars,
+/obj/item/device/binoculars,
+/obj/item/device/binoculars,
+/obj/item/device/binoculars,
+/obj/item/device/radio/headset/iccgn,
+/obj/item/device/radio/headset/iccgn,
+/obj/item/device/radio/headset/iccgn,
+/obj/item/device/radio/headset/iccgn,
+/obj/item/crowbar/prybar,
+/obj/item/crowbar/prybar,
+/obj/item/crowbar/prybar,
+/obj/item/crowbar/prybar,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/recharger/wallcharger{
+	pixel_x = 25;
 	dir = 8
 	},
 /turf/simulated/floor/plating,
@@ -655,22 +703,18 @@
 /obj/floor_decal/techfloor{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5;
-	icon_state = "intact"
-	},
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/icgnv_hound)
 "yo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 10
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/floor_decal/techfloor/corner{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 6
 	},
 /turf/simulated/floor/tiled/dark,
 /area/map_template/icgnv_hound)
@@ -679,6 +723,9 @@
 	dir = 4
 	},
 /obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 9
+	},
 /turf/simulated/floor/tiled/dark,
 /area/map_template/icgnv_hound)
 "zn" = (
@@ -757,8 +804,7 @@
 	dir = 8
 	},
 /obj/machinery/door/airlock/centcom{
-	name = "Medical";
-	opacity = 1
+	name = "Medical"
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/map_template/icgnv_hound)
@@ -826,8 +872,7 @@
 /area/map_template/icgnv_hound)
 "EG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5;
-	icon_state = "intact"
+	dir = 5
 	},
 /turf/simulated/floor/tiled/dark,
 /area/map_template/icgnv_hound)
@@ -849,11 +894,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/map_template/icgnv_hound)
 "Fp" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/machinery/recharger/wallcharger{
-	pixel_y = 24
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
 	},
 /turf/simulated/floor/plating,
 /area/map_template/icgnv_hound)
@@ -906,16 +948,13 @@
 	dir = 8
 	},
 /obj/machinery/door/airlock/centcom{
-	name = "Armory";
-	opacity = 1
+	name = "Armory"
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/map_template/icgnv_hound)
 "Gt" = (
 /obj/floor_decal/techfloor,
-/obj/machinery/recharger/wallcharger{
-	pixel_y = 24
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/icgnv_hound)
 "Gw" = (
@@ -947,6 +986,12 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/map_template/icgnv_hound)
+"GR" = (
+/obj/machinery/shipsensors,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
+/area/template_noop)
 "Hg" = (
 /obj/floor_decal/techfloor{
 	dir = 9
@@ -1108,8 +1153,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 9;
-	icon_state = "intact"
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
@@ -1137,6 +1181,13 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
+/area/map_template/icgnv_hound)
+"MP" = (
+/obj/machinery/door/blast/regular{
+	id_tag = "hound_pod_1_access";
+	name = "missile pod"
+	},
+/turf/simulated/floor/plating,
 /area/map_template/icgnv_hound)
 "Ng" = (
 /obj/floor_decal/techfloor/corner{
@@ -1258,10 +1309,17 @@
 	dir = 8
 	},
 /obj/machinery/door/airlock/centcom{
-	name = "Shields & Power";
-	opacity = 1
+	name = "Shields & Power"
 	},
 /turf/simulated/floor/tiled/dark/monotile,
+/area/map_template/icgnv_hound)
+"RC" = (
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/recharger/wallcharger{
+	pixel_x = -25;
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
 /area/map_template/icgnv_hound)
 "RJ" = (
 /obj/machinery/ion_engine{
@@ -1569,6 +1627,10 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/map_template/icgnv_hound)
 "Zx" = (
+/obj/machinery/door/blast/regular{
+	id_tag = "hound_pod_2_access";
+	name = "missile pod"
+	},
 /turf/simulated/floor/plating{
 	map_airless = 1
 	},
@@ -1661,10 +1723,10 @@ av
 av
 av
 av
-av
 dq
 if
-PQ
+GR
+cc
 os
 rs
 wt
@@ -1686,9 +1748,9 @@ av
 av
 av
 av
-av
-PQ
-fM
+iY
+oF
+xn
 Fp
 JS
 fM
@@ -1709,9 +1771,9 @@ av
 av
 av
 av
-av
 mA
-cc
+PQ
+fM
 rv
 wU
 DM
@@ -1732,9 +1794,9 @@ av
 av
 av
 av
-av
+kh
 mK
-oF
+MP
 rR
 xz
 fM
@@ -1799,7 +1861,7 @@ av
 cc
 cj
 gZ
-iY
+Cu
 ki
 lt
 mT
@@ -1822,7 +1884,7 @@ Cm
 cc
 cJ
 gZ
-jB
+Cu
 kE
 mh
 fM
@@ -1893,9 +1955,9 @@ av
 av
 av
 av
-av
+hv
 nz
-wp
+Zx
 vo
 yn
 fM
@@ -1916,9 +1978,9 @@ av
 av
 av
 av
-av
-Zx
-cc
+mA
+PQ
+fM
 vw
 yo
 FQ
@@ -1939,9 +2001,9 @@ av
 av
 av
 av
-av
-PQ
-PQ
+cy
+wp
+RC
 Gt
 yt
 fM
@@ -1960,10 +2022,10 @@ av
 av
 av
 av
-av
 dq
 if
-PQ
+jB
+cc
 pq
 vE
 zn

--- a/mods/_maps/general_maps/maps/sfv_arbiter.dmm
+++ b/mods/_maps/general_maps/maps/sfv_arbiter.dmm
@@ -2,8 +2,7 @@
 "al" = (
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -17,11 +16,6 @@
 "au" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 32
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /obj/floor_decal/corner/grey{
 	dir = 1
@@ -77,13 +71,11 @@
 	dir = 4
 	},
 /obj/floor_decal/corner/red{
-	dir = 9;
-	icon_state = "corner_white"
+	dir = 9
 	},
 /obj/machinery/light{
 	dir = 8;
-	icon_state = "tube1";
-	pixel_y = 0
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/map_template/sfv_arbiter)
@@ -135,21 +127,9 @@
 "dv" = (
 /obj/structure/closet/secure_closet/chemical,
 /obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 2;
 	level = 2
 	},
 /turf/simulated/floor/tiled/white,
-/area/map_template/sfv_arbiter)
-"dR" = (
-/obj/structure/bed/chair/shuttle/black{
-	dir = 8
-	},
-/obj/floor_decal/corner/grey/mono,
-/obj/item/clothing/head/helmet,
-/obj/item/modular_computer/telescreen/preset/navigation{
-	pixel_x = 32
-	},
-/turf/simulated/floor/tiled/dark/monotile,
 /area/map_template/sfv_arbiter)
 "et" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -173,10 +153,7 @@
 	dir = 4
 	},
 /obj/structure/table/glass,
-/obj/item/reagent_containers/glass/beaker/cryoxadone{
-	pixel_x = 0;
-	pixel_y = 0
-	},
+/obj/item/reagent_containers/glass/beaker/cryoxadone,
 /turf/simulated/floor/tiled/white,
 /area/map_template/sfv_arbiter)
 "gS" = (
@@ -209,8 +186,7 @@
 /area/map_template/sfv_arbiter)
 "it" = (
 /obj/floor_decal/industrial/warning{
-	dir = 1;
-	icon_state = "stripe"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -226,8 +202,7 @@
 /obj/structure/closet/crate/radiation,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/floor_decal/industrial/warning{
-	dir = 1;
-	icon_state = "stripe"
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/map_template/sfv_arbiter)
@@ -243,15 +218,13 @@
 /area/map_template/sfv_arbiter)
 "jM" = (
 /obj/floor_decal/corner/red{
-	dir = 4;
-	icon_state = "corner_white"
+	dir = 4
 	},
 /obj/structure/bed/chair/shuttle/black{
 	dir = 4
 	},
 /obj/floor_decal/corner/red{
-	dir = 9;
-	icon_state = "corner_white"
+	dir = 9
 	},
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -303,11 +276,6 @@
 	},
 /obj/floor_decal/industrial/warning{
 	dir = 8
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -441,8 +409,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 9;
-	icon_state = "intact"
+	dir = 9
 	},
 /turf/simulated/floor/tiled/white,
 /area/map_template/sfv_arbiter)
@@ -457,17 +424,6 @@
 /obj/item/device/radio/headset/sfv_arbiter,
 /obj/item/device/radio/headset/sfv_arbiter,
 /turf/simulated/floor/tiled,
-/area/map_template/sfv_arbiter)
-"od" = (
-/obj/floor_decal/corner/grey{
-	dir = 5
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/dark,
 /area/map_template/sfv_arbiter)
 "ow" = (
 /obj/structure/table/steel_reinforced,
@@ -515,15 +471,13 @@
 /area/map_template/sfv_arbiter)
 "qn" = (
 /obj/machinery/bodyscanner{
-	dir = 4;
-	icon_state = "body_scanner_0"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/map_template/sfv_arbiter)
 "qq" = (
 /obj/structure/table/steel_reinforced,
 /obj/machinery/button/blast_door{
-	icon_state = "doorctrl0";
 	id_tag = "rescuebridge";
 	name = "Window Shutters Control";
 	pixel_x = 4
@@ -533,9 +487,15 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/map_template/sfv_arbiter)
 "qt" = (
-/obj/paint/black,
-/obj/machinery/vending/medical,
-/turf/simulated/wall/titanium,
+/obj/machinery/payload_interface{
+	name = "Missile Pod 3";
+	id_tag = "arbiter_pod_3";
+	allow_arming = 1
+	},
+/obj/structure/missile/antispace{
+	dir = 1
+	},
+/turf/simulated/floor/airless,
 /area/map_template/sfv_arbiter)
 "qv" = (
 /obj/machinery/airlock_sensor/airlock_exterior{
@@ -577,17 +537,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/map_template/sfv_arbiter)
 "qP" = (
-/obj/structure/bed/chair/shuttle/black{
-	dir = 4
-	},
 /obj/floor_decal/corner/grey/mono,
-/obj/item/clothing/head/helmet,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/item/modular_computer/telescreen/preset/navigation{
+	pixel_x = -32
 	},
-/turf/simulated/floor/tiled/dark/monotile,
+/obj/structure/bed/chair/shuttle/black,
+/obj/item/clothing/head/helmet,
+/turf/simulated/floor/plating,
 /area/map_template/sfv_arbiter)
 "sH" = (
 /obj/structure/catwalk,
@@ -628,8 +584,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/floor_decal/corner/yellow/full,
 /obj/machinery/door/airlock/centcom{
-	name = "Armory";
-	opacity = 1
+	name = "Armory"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/map_template/sfv_arbiter)
@@ -773,8 +728,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/floor_decal/corner/yellow{
-	dir = 5;
-	icon_state = "corner_white"
+	dir = 5
 	},
 /turf/simulated/floor/tiled,
 /area/map_template/sfv_arbiter)
@@ -917,8 +871,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 9;
-	icon_state = "intact"
+	dir = 9
 	},
 /turf/simulated/floor/tiled/dark,
 /area/map_template/sfv_arbiter)
@@ -961,11 +914,6 @@
 /obj/floor_decal/industrial/warning/corner{
 	dir = 8
 	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/tiled/dark,
 /area/map_template/sfv_arbiter)
 "Cj" = (
@@ -983,8 +931,7 @@
 	},
 /obj/machinery/light{
 	dir = 8;
-	icon_state = "tube1";
-	pixel_y = 0
+	icon_state = "tube1"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled/techfloor,
@@ -1013,21 +960,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/map_template/sfv_arbiter)
 "DI" = (
-/obj/wallframe_spawn/reinforced/titanium,
-/obj/structure/cable/cyan{
-	d2 = 4;
-	icon_state = "0-4"
+/obj/machinery/door/blast/regular{
+	id_tag = "arbiter_pod_1"
 	},
-/obj/machinery/door/blast/regular/escape_pod{
-	id_tag = "rescuedock";
-	name = "External Blast Shield"
-	},
-/obj/paint/iccgn,
-/obj/structure/cable/cyan{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/airless,
 /area/map_template/sfv_arbiter)
 "DK" = (
 /obj/floor_decal/corner/blue{
@@ -1058,8 +994,7 @@
 /area/map_template/sfv_arbiter)
 "Eh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 9;
-	icon_state = "intact"
+	dir = 9
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/map_template/sfv_arbiter)
@@ -1128,27 +1063,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/sfv_arbiter)
-"EU" = (
-/obj/structure/bed/chair/shuttle/black{
-	dir = 4
-	},
-/obj/floor_decal/corner/grey/mono,
-/obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_y = 0
-	},
-/obj/item/clothing/head/helmet,
-/obj/item/modular_computer/telescreen/preset/navigation{
-	pixel_x = -32
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/map_template/sfv_arbiter)
 "EW" = (
 /obj/machinery/vitals_monitor,
 /turf/simulated/floor/tiled/white,
@@ -1208,15 +1122,13 @@
 	icon_state = "warning"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 9;
-	icon_state = "intact"
+	dir = 9
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/sfv_arbiter)
 "HR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5;
-	icon_state = "intact"
+	dir = 5
 	},
 /obj/shuttle_landmark/sfv_arbiter/start,
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -1254,8 +1166,7 @@
 "Is" = (
 /obj/floor_decal/corner/b_green/full,
 /obj/machinery/door/airlock/centcom{
-	name = "EVA";
-	opacity = 1
+	name = "EVA"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -1274,8 +1185,7 @@
 "IH" = (
 /obj/machinery/light{
 	dir = 8;
-	icon_state = "tube1";
-	pixel_y = 0
+	icon_state = "tube1"
 	},
 /obj/floor_decal/industrial/warning/corner{
 	dir = 1
@@ -1328,7 +1238,6 @@
 "Jz" = (
 /obj/floor_decal/industrial/outline/yellow,
 /obj/machinery/fabricator/hacked,
-/obj/item/storage/box/autolathe_designs,
 /turf/simulated/floor/tiled/dark,
 /area/map_template/sfv_arbiter)
 "JO" = (
@@ -1367,24 +1276,6 @@
 /obj/structure/window/boron_reinforced{
 	dir = 1
 	},
-/turf/simulated/floor/plating,
-/area/map_template/sfv_arbiter)
-"KK" = (
-/obj/wallframe_spawn/reinforced/titanium,
-/obj/structure/cable/cyan{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/structure/cable/cyan{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/door/blast/regular/escape_pod{
-	id_tag = "rescuedock";
-	name = "External Blast Shield"
-	},
-/obj/paint/iccgn,
-/obj/paint/iccgn,
 /turf/simulated/floor/plating,
 /area/map_template/sfv_arbiter)
 "KO" = (
@@ -1536,8 +1427,7 @@
 	dir = 10
 	},
 /obj/floor_decal/corner/b_green{
-	dir = 5;
-	icon_state = "corner_white"
+	dir = 5
 	},
 /obj/structure/cable/cyan{
 	d1 = 2;
@@ -1549,8 +1439,7 @@
 "Mx" = (
 /obj/paint/black,
 /obj/structure/sign/warning/high_voltage{
-	dir = 8;
-	icon_state = "shock"
+	dir = 8
 	},
 /turf/simulated/wall/titanium,
 /area/map_template/sfv_arbiter)
@@ -1572,16 +1461,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/map_template/sfv_arbiter)
 "Nf" = (
-/obj/structure/table/steel_reinforced,
-/obj/machinery/button/blast_door{
-	icon_state = "doorctrl0";
-	id_tag = "rescuebridge";
-	name = "Window Shutters Control";
-	pixel_x = -4;
-	pixel_y = 4
-	},
 /obj/floor_decal/corner/blue/mono,
-/obj/item/device/radio/headset/sfv_arbiter,
+/obj/machinery/computer/modular/preset/munitions/syndicate{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/map_template/sfv_arbiter)
 "Nh" = (
@@ -1645,17 +1528,10 @@
 /turf/simulated/floor/tiled,
 /area/map_template/sfv_arbiter)
 "NO" = (
-/obj/wallframe_spawn/reinforced/titanium,
-/obj/structure/cable/cyan{
-	d2 = 8;
-	icon_state = "0-8"
+/obj/machinery/door/blast/regular{
+	id_tag = "arbiter_pod_3"
 	},
-/obj/machinery/door/blast/regular/escape_pod{
-	id_tag = "rescuedock";
-	name = "External Blast Shield"
-	},
-/obj/paint/iccgn,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/airless,
 /area/map_template/sfv_arbiter)
 "NV" = (
 /obj/structure/cable/cyan{
@@ -1718,8 +1594,7 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/centcom{
-	name = "Shields & Power";
-	opacity = 1
+	name = "Shields & Power"
 	},
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -1756,8 +1631,7 @@
 	},
 /obj/item/device/radio/intercom/specops{
 	dir = 8;
-	pixel_x = 22;
-	pixel_y = 0
+	pixel_x = 22
 	},
 /turf/simulated/floor/tiled/dark,
 /area/map_template/sfv_arbiter)
@@ -1783,8 +1657,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/airlock/centcom{
-	name = "Holding Area";
-	opacity = 1
+	name = "Holding Area"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/map_template/sfv_arbiter)
@@ -1793,8 +1666,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/floor_decal/corner/white/full,
 /obj/machinery/door/airlock/centcom{
-	name = "Medical";
-	opacity = 1
+	name = "Medical"
 	},
 /turf/simulated/floor/tiled/white,
 /area/map_template/sfv_arbiter)
@@ -1842,21 +1714,10 @@
 /turf/simulated/floor/plating,
 /area/map_template/sfv_arbiter)
 "QF" = (
-/obj/wallframe_spawn/reinforced/titanium,
-/obj/structure/cable/cyan{
-	d2 = 8;
-	icon_state = "0-8"
+/obj/machinery/door/blast/regular{
+	id_tag = "arbiter_pod_2"
 	},
-/obj/structure/cable/cyan{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/door/blast/regular/escape_pod{
-	id_tag = "rescuedock";
-	name = "External Blast Shield"
-	},
-/obj/paint/iccgn,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/airless,
 /area/map_template/sfv_arbiter)
 "QG" = (
 /obj/structure/catwalk,
@@ -1877,8 +1738,7 @@
 /area/map_template/sfv_arbiter)
 "QQ" = (
 /obj/floor_decal/industrial/warning{
-	dir = 1;
-	icon_state = "stripe"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -1922,12 +1782,19 @@
 "RK" = (
 /obj/floor_decal/corner/blue/mono,
 /obj/machinery/light/spot,
+/obj/structure/table/steel_reinforced,
+/obj/machinery/button/blast_door{
+	id_tag = "rescuebridge";
+	name = "Window Shutters Control";
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/item/device/radio/headset/sfv_arbiter,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/map_template/sfv_arbiter)
 "RM" = (
 /obj/floor_decal/corner/blue{
-	dir = 8;
-	icon_state = "corner_white"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/map_template/sfv_arbiter)
@@ -1988,8 +1855,7 @@
 /area/map_template/sfv_arbiter)
 "Sy" = (
 /obj/floor_decal/corner/red{
-	dir = 1;
-	icon_state = "corner_white"
+	dir = 1
 	},
 /obj/floor_decal/corner/red{
 	dir = 6
@@ -2052,22 +1918,10 @@
 /obj/floor_decal/industrial/warning/corner,
 /turf/simulated/floor/tiled/dark,
 /area/map_template/sfv_arbiter)
-"TZ" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/floor_decal/corner/grey{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/dark,
-/area/map_template/sfv_arbiter)
 "Ue" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/floor_decal/corner/yellow{
-	dir = 10;
-	icon_state = "corner_white"
+	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
@@ -2085,7 +1939,6 @@
 /obj/structure/iv_stand,
 /obj/structure/closet/secure_closet/medical_wall{
 	name = "IV Equipment Cabinet";
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/item/reagent_containers/ivbag/nanoblood,
@@ -2233,11 +2086,6 @@
 /obj/floor_decal/corner/grey{
 	dir = 5
 	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /turf/simulated/floor/tiled/dark,
 /area/map_template/sfv_arbiter)
 "VU" = (
@@ -2276,7 +2124,6 @@
 	id_tag = "sfv_arbiter_shuttle_pump"
 	},
 /obj/machinery/button/blast_door{
-	icon_state = "doorctrl0";
 	id_tag = "rescuedock";
 	name = "Window Shutters Control";
 	pixel_x = 24;
@@ -2325,10 +2172,15 @@
 /turf/simulated/wall/titanium,
 /area/map_template/sfv_arbiter)
 "WW" = (
-/obj/floor_decal/corner/grey{
-	dir = 9
+/obj/machinery/payload_interface{
+	name = "Missile Pod 2";
+	id_tag = "arbiter_pod_2";
+	allow_arming = 1
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/structure/missile/he{
+	dir = 1
+	},
+/turf/simulated/floor/airless,
 /area/map_template/sfv_arbiter)
 "Xa" = (
 /obj/structure/catwalk,
@@ -2338,12 +2190,6 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
-/area/map_template/sfv_arbiter)
-"Xd" = (
-/obj/floor_decal/corner/grey{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/dark,
 /area/map_template/sfv_arbiter)
 "Xl" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -2438,28 +2284,32 @@
 /area/map_template/sfv_arbiter)
 "XU" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 5;
-	icon_state = "intact"
+	dir = 5
 	},
 /turf/simulated/floor/tiled/white,
 /area/map_template/sfv_arbiter)
 "Yb" = (
-/obj/floor_decal/corner/grey/three_quarters,
-/turf/simulated/floor/tiled/dark,
+/obj/floor_decal/corner/grey/mono,
+/obj/structure/bed/chair/shuttle/black,
+/obj/item/clothing/head/helmet,
+/turf/simulated/floor/plating,
 /area/map_template/sfv_arbiter)
 "Yl" = (
-/obj/floor_decal/corner/grey/three_quarters{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/map_template/sfv_arbiter)
+/obj/paint/iccgn,
+/turf/simulated/wall/r_titanium,
+/area/template_noop)
 "Yn" = (
-/obj/structure/bed/chair/shuttle/black{
-	dir = 8
-	},
 /obj/floor_decal/corner/grey/mono,
+/obj/item/modular_computer/telescreen/preset/navigation{
+	pixel_x = 32
+	},
+/obj/structure/bed/chair/shuttle/black,
 /obj/item/clothing/head/helmet,
-/turf/simulated/floor/tiled/dark/monotile,
+/obj/item/flame/lighter/zippo/gunmetal{
+	pixel_x = 5
+	},
+/obj/item/storage/fancy/smokable/transstellar,
+/turf/simulated/floor/plating,
 /area/map_template/sfv_arbiter)
 "YA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -2496,28 +2346,18 @@
 /area/map_template/sfv_arbiter)
 "YN" = (
 /obj/floor_decal/corner/grey/mono,
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/plating,
 /area/map_template/sfv_arbiter)
 "YR" = (
 /obj/floor_decal/corner/grey/mono,
-/obj/structure/reagent_dispensers/water_cooler{
-	dir = 8;
-	icon_state = "water_cooler"
-	},
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/plating,
 /area/map_template/sfv_arbiter)
 "YT" = (
 /obj/floor_decal/corner/white{
-	dir = 4;
-	icon_state = "corner_white"
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/map_template/sfv_arbiter)
@@ -2528,7 +2368,6 @@
 	icon_state = "1-2"
 	},
 /obj/floor_decal/industrial/warning/corner{
-	dir = 2;
 	icon_state = "warningcorner"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -2536,44 +2375,17 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/map_template/sfv_arbiter)
-"Zf" = (
-/obj/machinery/button/blast_door{
-	icon_state = "doorctrl0";
-	id_tag = "rescuedock";
-	name = "Window Shutters Control";
-	pixel_x = -24;
-	pixel_y = -4
-	},
-/obj/floor_decal/corner/grey/mono,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/table/steel_reinforced,
-/obj/item/flame/lighter/zippo/gunmetal{
-	pixel_x = 5
-	},
-/obj/item/storage/fancy/smokable/transstellar,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/map_template/sfv_arbiter)
 "Zj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/floor_decal/corner/white{
 	dir = 5
 	},
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /turf/simulated/floor/tiled/dark,
 /area/map_template/sfv_arbiter)
 "Zk" = (
 /obj/floor_decal/corner/white{
-	dir = 1;
-	icon_state = "corner_white"
+	dir = 1
 	},
 /obj/structure/sign/warning/nosmoking_1{
 	pixel_y = 23
@@ -2594,15 +2406,20 @@
 	},
 /obj/floor_decal/corner/blue/full,
 /obj/machinery/door/airlock/centcom{
-	name = "Bridge";
-	opacity = 1
+	name = "Bridge"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/map_template/sfv_arbiter)
 "Zu" = (
-/obj/paint/black,
-/obj/paint/iccgn,
-/turf/simulated/wall/r_titanium,
+/obj/machinery/payload_interface{
+	name = "Missile Pod 1";
+	id_tag = "arbiter_pod_1";
+	allow_arming = 1
+	},
+/obj/structure/missile/he{
+	dir = 1
+	},
+/turf/simulated/floor/airless,
 /area/map_template/sfv_arbiter)
 "Zv" = (
 /obj/floor_decal/corner/yellow{
@@ -2800,12 +2617,12 @@ VG
 et
 XO
 aq
-XH
+sS
 XH
 "}
 (10,1,1) = {"
 XH
-XH
+Yl
 aq
 aq
 LU
@@ -2819,12 +2636,12 @@ VJ
 BE
 WV
 aq
-sS
+Yl
 XH
 "}
 (11,1,1) = {"
 XH
-aq
+DI
 Zu
 WV
 WV
@@ -2837,17 +2654,17 @@ WV
 WV
 WV
 WV
-aq
+WV
 aq
 gS
 "}
 (12,1,1) = {"
 XH
-DI
-Zf
-EU
+aq
+aq
+WV
 qP
-qP
+YN
 VT
 IU
 SK
@@ -2864,10 +2681,10 @@ XH
 XH
 QF
 WW
-WW
+WV
 Yb
 YN
-od
+VT
 VU
 XP
 Dx
@@ -2881,12 +2698,12 @@ XH
 "}
 (14,1,1) = {"
 Pp
-KK
-Xd
-Xd
-Yl
+aq
+aq
+WV
+Yb
 YN
-TZ
+VT
 FJ
 yb
 it
@@ -2901,11 +2718,11 @@ XH
 (15,1,1) = {"
 XH
 NO
-Yn
-dR
+qt
+WV
 Yn
 YR
-TZ
+VT
 Nh
 NV
 QS
@@ -2942,7 +2759,7 @@ aq
 WL
 XU
 fO
-qt
+WV
 YT
 FJ
 Og

--- a/mods/antagonists/maps/mercenary_base.dmm
+++ b/mods/antagonists/maps/mercenary_base.dmm
@@ -256,9 +256,7 @@
 /turf/simulated/floor/plating,
 /area/map_template/merc_shuttle)
 "cE" = (
-/obj/machinery/computer/ship/helm{
-	uncreated_component_parts = list(/obj/item/stock_parts/computer/ship_interface)
-	},
+/obj/machinery/computer/ship/helm,
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/merc_shuttle)
 "cG" = (
@@ -274,9 +272,12 @@
 /turf/simulated/floor/plating,
 /area/map_template/merc_shuttle)
 "cH" = (
-/obj/machinery/door/blast/regular{
-	id_tag = "merc_bsa"
+/obj/wallframe_spawn/reinforced/titanium,
+/obj/machinery/door/blast/regular/open{
+	density = 0;
+	id_tag = "merc_external"
 	},
+/obj/paint/merc,
 /turf/simulated/floor/plating,
 /area/map_template/merc_shuttle)
 "cI" = (
@@ -311,13 +312,17 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/merc_shuttle)
 "cO" = (
-/obj/machinery/disperser/front{
-	dir = 1
+/obj/wallframe_spawn/reinforced/titanium,
+/obj/machinery/door/blast/regular/open{
+	density = 0;
+	dir = 4;
+	id_tag = "merc_external"
 	},
+/obj/paint/merc,
 /turf/simulated/floor/plating,
 /area/map_template/merc_shuttle)
 "cQ" = (
-/obj/machinery/computer/ship/disperser,
+/obj/machinery/computer/modular/preset/munitions/syndicate,
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/merc_shuttle)
 "cS" = (
@@ -358,10 +363,10 @@
 /turf/simulated/floor/tiled/white,
 /area/map_template/merc_spawn)
 "dn" = (
-/obj/machinery/disperser/middle{
-	dir = 1
+/obj/machinery/door/blast/regular{
+	id_tag = "merc_pod"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/airless,
 /area/map_template/merc_shuttle)
 "dq" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -414,15 +419,15 @@
 "em" = (
 /obj/structure/table/steel_reinforced,
 /obj/machinery/button/blast_door{
-	id_tag = "merc_bsa";
-	name = "OFD Firing Blast Doors";
+	id_tag = "merc_pod_access";
+	name = "Missile Pod Access";
 	pixel_x = -5;
 	pixel_y = 6;
 	req_access = list("ACCESS_SYNDICATE")
 	},
 /obj/machinery/button/blast_door{
 	id_tag = "merc_bsa_shutters";
-	name = "OFD Viewing Shutters";
+	name = "Missile Pod Viewing Shutters";
 	pixel_x = -5;
 	pixel_y = -3;
 	req_access = list("ACCESS_SYNDICATE")
@@ -482,11 +487,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/map_template/merc_shuttle)
 "eG" = (
-/obj/machinery/disperser/back{
-	dir = 1
+/obj/machinery/payload_interface{
+	name = "Missile Pod";
+	id_tag = "merc_pod";
+	allow_arming = 1
 	},
-/obj/structure/ship_munition/disperser_charge/emp,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/airless,
 /area/map_template/merc_shuttle)
 "eR" = (
 /obj/machinery/cryopod{
@@ -514,7 +520,6 @@
 /obj/machinery/door/blast/regular/open{
 	density = 0;
 	dir = 4;
-	icon_state = "pdoor0";
 	id_tag = "merc_bsa_shutters"
 	},
 /obj/paint/merc,
@@ -604,16 +609,17 @@
 /turf/simulated/floor/plating,
 /area/map_template/merc_spawn)
 "gr" = (
-/obj/machinery/door/blast/regular/open{
-	density = 0;
-	icon_state = "pdoor0";
-	id_tag = "merc_bsa"
-	},
 /obj/floor_decal/industrial/warning{
 	dir = 8
 	},
 /obj/floor_decal/industrial/warning{
 	dir = 4
+	},
+/obj/machinery/door/blast/regular{
+	id_tag = "merc_pod_access";
+	name = "missile pod";
+	density = 0;
+	icon_state = "pdoor0"
 	},
 /turf/simulated/floor/plating,
 /area/map_template/merc_shuttle)
@@ -1611,11 +1617,15 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/merc_shuttle)
 "qY" = (
-/obj/floor_decal/industrial/outline/red,
 /obj/structure/railing{
 	dir = 1
 	},
 /obj/structure/railing,
+/obj/structure/missile/probe,
+/obj/floor_decal/industrial/outline{
+	color = "#55007f";
+	name = "purple outline"
+	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/map_template/merc_shuttle)
 "qZ" = (
@@ -1749,7 +1759,8 @@
 /obj/structure/railing{
 	dir = 1
 	},
-/obj/floor_decal/industrial/outline/blue,
+/obj/floor_decal/industrial/outline/red,
+/obj/structure/missile/he,
 /turf/simulated/floor/tiled/dark,
 /area/map_template/merc_shuttle)
 "sO" = (
@@ -2671,12 +2682,11 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/map_template/merc_shuttle/drop_pod)
 "EF" = (
-/obj/floor_decal/industrial/outline/blue,
-/obj/structure/ship_munition/disperser_charge/emp,
 /obj/structure/railing{
 	dir = 1
 	},
 /obj/structure/railing,
+/obj/floor_decal/industrial/outline/blue,
 /turf/simulated/floor/tiled/dark,
 /area/map_template/merc_shuttle)
 "EK" = (
@@ -3389,12 +3399,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/map_template/merc_spawn)
 "VH" = (
-/obj/floor_decal/industrial/outline/red,
-/obj/structure/ship_munition/disperser_charge/explosive,
 /obj/structure/railing,
 /obj/structure/railing{
 	dir = 1
 	},
+/obj/floor_decal/industrial/outline/orange,
+/obj/structure/missile/antispace,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/map_template/merc_shuttle)
 "VJ" = (
@@ -5936,7 +5946,7 @@ aa
 aa
 aa
 aa
-St
+cH
 cN
 cW
 eA
@@ -6038,7 +6048,7 @@ aa
 aa
 aa
 cD
-St
+cH
 cE
 dY
 FR
@@ -6142,7 +6152,7 @@ aa
 AF
 AF
 fa
-fa
+AF
 fa
 AF
 hL
@@ -6242,8 +6252,8 @@ aa
 aa
 aa
 aa
-cH
-cO
+aa
+aa
 dn
 eG
 gr
@@ -6346,7 +6356,7 @@ aa
 AF
 AF
 fa
-fa
+AF
 fa
 AF
 hU
@@ -6446,7 +6456,7 @@ aa
 aa
 aa
 cD
-St
+cH
 cQ
 Qk
 eA
@@ -6548,7 +6558,7 @@ aa
 aa
 aa
 aa
-St
+cH
 cS
 eh
 nI
@@ -6754,10 +6764,10 @@ aa
 aa
 AF
 AF
-Jc
-Jc
-Jc
-Jc
+cO
+cO
+cO
+cO
 AF
 mi
 nW

--- a/mods/antagonists/maps/mercenary_base.dmm
+++ b/mods/antagonists/maps/mercenary_base.dmm
@@ -256,7 +256,9 @@
 /turf/simulated/floor/plating,
 /area/map_template/merc_shuttle)
 "cE" = (
-/obj/machinery/computer/ship/helm,
+/obj/machinery/computer/ship/helm{
+	uncreated_component_parts = list(/obj/item/stock_parts/computer/ship_interface)
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/merc_shuttle)
 "cG" = (

--- a/mods/antagonists/maps/mercenary_base.dmm
+++ b/mods/antagonists/maps/mercenary_base.dmm
@@ -366,7 +366,10 @@
 /obj/machinery/door/blast/regular{
 	id_tag = "merc_pod"
 	},
-/turf/simulated/floor/airless,
+/obj/floor_decal/industrial/warning/half{
+	dir = 4
+	},
+/turf/simulated/floor/reinforced,
 /area/map_template/merc_shuttle)
 "dq" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -487,12 +490,15 @@
 /turf/simulated/floor/tiled/dark,
 /area/map_template/merc_shuttle)
 "eG" = (
-/obj/machinery/payload_interface{
-	name = "Missile Pod";
-	id_tag = "merc_pod";
-	allow_arming = 1
+/obj/machinery/conveyor{
+	dir = 1;
+	id = null;
+	id_tag = "merc_pod_load"
 	},
-/turf/simulated/floor/airless,
+/obj/floor_decal/industrial/warning/half{
+	dir = 4
+	},
+/turf/simulated/floor/reinforced,
 /area/map_template/merc_shuttle)
 "eR" = (
 /obj/machinery/cryopod{
@@ -609,19 +615,26 @@
 /turf/simulated/floor/plating,
 /area/map_template/merc_spawn)
 "gr" = (
-/obj/floor_decal/industrial/warning{
-	dir = 8
-	},
-/obj/floor_decal/industrial/warning{
-	dir = 4
-	},
 /obj/machinery/door/blast/regular{
 	id_tag = "merc_pod_access";
 	name = "missile pod";
 	density = 0;
 	icon_state = "pdoor0"
 	},
-/turf/simulated/floor/plating,
+/obj/machinery/conveyor{
+	dir = 1;
+	id = null;
+	id_tag = "merc_pod_load"
+	},
+/obj/machinery/payload_interface{
+	name = "Missile Pod Loading";
+	id_tag = "merc_pod_load";
+	allow_arming = 1
+	},
+/obj/floor_decal/industrial/warning/half{
+	dir = 4
+	},
+/turf/simulated/floor/reinforced,
 /area/map_template/merc_shuttle)
 "gC" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -1826,6 +1839,17 @@
 /obj/floor_decal/corner/blue/mono,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/map_template/merc_spawn)
+"tT" = (
+/obj/machinery/payload_interface{
+	name = "Missile Pod";
+	id_tag = "merc_pod";
+	allow_arming = 1
+	},
+/obj/floor_decal/industrial/warning/half{
+	dir = 4
+	},
+/turf/simulated/floor/reinforced,
+/area/map_template/merc_shuttle)
 "tY" = (
 /obj/floor_decal/corner_techfloor_grid,
 /obj/floor_decal/techfloor/corner,
@@ -3499,6 +3523,18 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/map_template/merc_spawn)
+"XA" = (
+/obj/structure/plasticflaps/airtight,
+/obj/machinery/conveyor{
+	dir = 1;
+	id = null;
+	id_tag = "merc_pod_load"
+	},
+/obj/floor_decal/industrial/warning/half{
+	dir = 4
+	},
+/turf/simulated/floor/reinforced,
+/area/map_template/merc_shuttle)
 "XJ" = (
 /obj/floor_decal/corner/purple{
 	dir = 1
@@ -6252,9 +6288,9 @@ aa
 aa
 aa
 aa
-aa
-aa
 dn
+tT
+XA
 eG
 gr
 hR


### PR DESCRIPTION
<!-- ЗДЕСЬ должно быть **подробное описание** того, что происходит в PR и зачем это нужно. PR не должен содержать изменений, о которых здесь ничего не сказано. -->
Изменяем ОФД Наёмников на ракеты + твики ивентовых карт

<!-- ЗДЕСЬ нужно **привязать ишью**, которые относятся к PR'у в формате `close #1234` или `fixes #1234` - тогда они автоматически закроются вместе с PR. Можно написать `Затрагивает #1234, но не фиксит его`, если вы просто хотите упоминуть ишью, но не закрывать его. -->

<!-- ЗДЕСЬ нужно **расписать изменения** которые попадут в **чейнджлог**, формат - `prefix: краткое описание` -->
🆑LordNest, Teteshnik
maptweak: ОФД у наёмников заменено на ракетную шахту. Покупайте наборы для ракет в аплинке. На судне есть противоракета, зонд и фугасная ракета.
/🆑
<!--
  Честно заполняем галочки. Чем больше галочек, тем быстрее проверять Pull Request, соответственно он быстрее будет принят.
  Чтобы отметить - ставим `x` (икс) внутри квадратных скобочек вот так: `- [x] ...`.
  Галочки можно доставлять позже по мере окончания работы над PR'ом.
-->

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
