### PR TITLE
Кастомизация крестов и цветков

### DIFF
--- a/maps/sierra/loadout/loadout_accessories.dm
+++ b/maps/sierra/loadout/loadout_accessories.dm
@@ -154,29 +154,24 @@
 /datum/gear/accessory/cross_blue
 	display_name = "Cross blue"
 	path = /obj/item/clothing/accessory/cross_blue
-	flags = GEAR_HAS_NO_CUSTOMIZATION
 	cost = 2
 
 /datum/gear/accessory/cross_red
 	display_name = "Cross red"
 	path = /obj/item/clothing/accessory/cross_red
-	flags = GEAR_HAS_NO_CUSTOMIZATION
 	cost = 2
 
 /datum/gear/accessory/flower_gold
 	display_name = "Flower gold"
 	path = /obj/item/clothing/accessory/flower_gold
-	flags = GEAR_HAS_NO_CUSTOMIZATION
 	cost = 2
 
 /datum/gear/accessory/flower_silver
 	display_name = "Flower silver"
 	path = /obj/item/clothing/accessory/flower_silver
-	flags = GEAR_HAS_NO_CUSTOMIZATION
 	cost = 2
 
 /datum/gear/accessory/flower_bronze
 	display_name = "Flower bronze"
 	path = /obj/item/clothing/accessory/flower_bronze
-	flags = GEAR_HAS_NO_CUSTOMIZATION
 	cost = 2


### PR DESCRIPTION
ПР позволяет кастомизировать имена и описание красного и синего креста, а также всех трёх цветков, находящихся в Accessory.

<!-- ЗДЕСЬ нужно **привязать ишью**, которые относятся к PR'у в формате `close #1234` или `fixes #1234` - тогда они автоматически закроются вместе с PR. Можно написать `Затрагивает #1234, но не фиксит его`, если вы просто хотите упоминуть ишью, но не закрывать его. -->

<!-- ЗДЕСЬ нужно **расписать изменения** которые попадут в **чейнджлог**, формат - `prefix: краткое описание` -->
### Чейнджлог
```yml
🆑Unchi
tweak: Red Cross, Blue Cross, Bronze Flower, Silver Flower, Gold Flower теперь кастомизируемые.
/🆑
```

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
