### PR TITLE
Фикс для Alden-Saraspova counter

### DIFF
--- a/code/modules/xenoarcheaology/tools/tools.dm
+++ b/code/modules/xenoarcheaology/tools/tools.dm
@@ -67,7 +67,7 @@
 			else
 				SSxenoarch.xeno_artifact_turfs -= T
 
-		for(var/turf/simulated/mineral/T as anything in SSxenoarch.xeno_artifact_turfs)
+		for(var/turf/simulated/mineral/T as anything in SSxenoarch.xeno_digsite_turfs)
 			if(T.density && T.finds && length(T.finds))
 				if(T.z == cur_turf.z)
 					var/cur_dist = get_dist(cur_turf, T) * 2


### PR DESCRIPTION
<!-- ЗДЕСЬ должно быть **подробное описание** того, что происходит в PR и зачем это нужно. PR не должен содержать изменений, о которых здесь ничего не сказано. -->
Заменяет xeno_artifact_turfs на xeno_digsite_turfs. Непонятно откуда это было, но на оффах такого нет. Теперь все турфы с вещами от раскопок должны отображаться при использовании этого сканера. 

Такие турфы создаются при инициализации системы - от 6 до 12 турфов по всей карте с большими артефактами, и фиксированный шанс на мелкие - скан которых пофикшен сейчас.

Если например заспавнить карту с минералами по середине раунда, то там никаких аномальных объектов не будет.

<!-- ЗДЕСЬ нужно **привязать ишью**, которые относятся к PR'у в формате `close #1234` или `fixes #1234` - тогда они автоматически закроются вместе с PR. Можно написать `Затрагивает #1234, но не фиксит его`, если вы просто хотите упоминуть ишью, но не закрывать его. -->
close #4508

<!-- ЗДЕСЬ нужно **расписать изменения** которые попадут в **чейнджлог**, формат - `prefix: краткое описание` -->
### Чейнджлог
```yml
🆑Builder13
bugfix: Фикс отображения турфов с аномальными объектами для Alden-Saraspova counter
/🆑
```

<!--
  Честно заполняем галочки. Чем больше галочек, тем быстрее проверять Pull Request, соответственно он быстрее будет принят.
  Чтобы отметить - ставим `x` (икс) внутри квадратных скобочек вот так: `- [x] ...`.
  Галочки можно доставлять позже по мере окончания работы над PR'ом.
-->

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
