### PR TITLE
ПКМ чтобы понизить приоритет роли

### DIFF
--- a/code/modules/client/preference_setup/occupation/occupation.dm
+++ b/code/modules/client/preference_setup/occupation/occupation.dm
@@ -247,9 +247,11 @@
 							level_link = SPAN_COLOR("#55cc55", "High")
 						else
 							level_link = SPAN_COLOR("black", "Never")
+ 					// [SIERRA-EDIT]
 					. += {"<a onclick="setJobLevel('\ref[src]', '[title]', -1)" \
 							oncontextmenu="javascript:return setJobLevel('\ref[src]', '[title]', 1)">\
-							[level_link]</a>"} // [SIERRA-EDIT]
+							[level_link]</a>"}
+					// [/SIERRA-EDIT]
 				. += "</td></tr>"
 			. += "</td></tr></table>"
 			. += "</center></table><center>"

--- a/code/modules/client/preference_setup/occupation/occupation.dm
+++ b/code/modules/client/preference_setup/occupation/occupation.dm
@@ -247,7 +247,9 @@
 							level_link = SPAN_COLOR("#55cc55", "High")
 						else
 							level_link = SPAN_COLOR("black", "Never")
-					. += "<a href='byond://?src=\ref[src];set_job=[title];inc_level=-1'>[level_link]</a>"
+					. += {"<a onclick="setJobLevel('\ref[src]', '[title]', -1)" \
+							oncontextmenu="javascript:return setJobLevel('\ref[src]', '[title]', 1)">\
+							[level_link]</a>"} // [SIERRA-EDIT]
 				. += "</td></tr>"
 			. += "</td></tr></table>"
 			. += "</center></table><center>"

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -163,6 +163,11 @@
 		function update_content(data){
 			document.getElementById('content').innerHTML = data;
 		}
+		function setJobLevel(source, title, level)
+		{
+			window.location.href = "byond://?src=" + source + ";set_job=" + title + ";inc_level=" + level;
+			return 1;
+		} // \[SIERRA-ADD]
 	</script>
 	<div id='content'>[get_content(user)]</div>
 	"}

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -163,11 +163,13 @@
 		function update_content(data){
 			document.getElementById('content').innerHTML = data;
 		}
+		// \[SIERRA-ADD]
 		function setJobLevel(source, title, level)
 		{
 			window.location.href = "byond://?src=" + source + ";set_job=" + title + ";inc_level=" + level;
 			return 1;
-		} // \[SIERRA-ADD]
+		}
+		// \[/SIERRA-ADD]
 	</script>
 	<div id='content'>[get_content(user)]</div>
 	"}


### PR DESCRIPTION
В настройке приоритетов ролей персонажа теперь можно на ПКМ понизить (или сразу на HIGH выставить роль с NEVER).

### Чейнджлог
```yml
🆑AlexMorgan3817 (_Elar_)
tweak: ПКМ в настройке приоритетов ролей теперь понижает приоритет роли и работает циклично (Если нажать ПКМ на роль с NEVER, она станет HIGH приоритета)
/🆑
```

- [X] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [X] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [X] Я запускал сервер со своими изменениями локально и все протестировал.