### PR TITLE
Фикс времени объявления войны наемников

### DIFF
--- a/mods/mechs_by_shegar/code/etc/mech_uplink.dm
+++ b/mods/mechs_by_shegar/code/etc/mech_uplink.dm
@@ -9,7 +9,7 @@ GLOBAL_VAR_AS(war_declared, FALSE)
 	antag_roles = list(MODE_MERCENARY)
 
 /datum/uplink_item/item/services/assault_declaration/get_goods(obj/item/device/uplink/U, loc)
-	if(world.time > 15 MINUTES)
+	if(round_duration_in_ticks > 15 MINUTES)
 		to_chat(usr, SPAN_BAD("Дополнительные средства не могут быть выделены, прошло слишком много времени."))
 		return
 	if(GLOB.war_declared)


### PR DESCRIPTION
<!-- ЗДЕСЬ должно быть **подробное описание** того, что происходит в PR и зачем это нужно. PR не должен содержать изменений, о которых здесь ничего не сказано. -->
Объявление войны наемников больше не учитывает время из лобби, до старта раунда

<!-- ЗДЕСЬ нужно **привязать ишью**, которые относятся к PR'у в формате `close #1234` или `fixes #1234` - тогда они автоматически закроются вместе с PR. Можно написать `Затрагивает #1234, но не фиксит его`, если вы просто хотите упоминуть ишью, но не закрывать его. -->
close #4639

<!-- ЗДЕСЬ нужно **расписать изменения** которые попадут в **чейнджлог**, формат - `prefix: краткое описание` -->
### Чейнджлог
```yml
🆑Builder13
bugfix: Объявление войны наемников больше не учитывает время из лобби, до старта раунда
/🆑
```

<!--
  Честно заполняем галочки. Чем больше галочек, тем быстрее проверять Pull Request, соответственно он быстрее будет принят.
  Чтобы отметить - ставим `x` (икс) внутри квадратных скобочек вот так: `- [x] ...`.
  Галочки можно доставлять позже по мере окончания работы над PR'ом.
-->

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
