### PR TITLE
Фикс стальных бронеплит

### DIFF
--- a/packs/infinity/clothing/accessories/armor.dm
+++ b/packs/infinity/clothing/accessories/armor.dm
@@ -18,6 +18,7 @@
 		energy = ARMOR_ENERGY_MINOR,
 		bomb = ARMOR_BOMB_MINOR
 		)
+	slot = ACCESSORY_SLOT_ARMOR_CHEST
 	slowdown = 0.25
 
 /obj/item/clothing/accessory/armorplate/mainkraft/medium
@@ -32,6 +33,7 @@
 		energy = ARMOR_ENERGY_SMALL,
 		bomb = ARMOR_BOMB_PADDED
 		)
+	slot = ACCESSORY_SLOT_ARMOR_CHEST
 	slowdown = 0.5
 
 /obj/item/clothing/accessory/armorplate/mainkraft/heavy
@@ -46,4 +48,5 @@
 		energy = ARMOR_ENERGY_RESISTANT,
 		bomb = ARMOR_BOMB_PADDED
 		)
+	slot = ACCESSORY_SLOT_ARMOR_CHEST
 	slowdown = 0.75


### PR DESCRIPTION
Вчера проглядел, что плиты могут пристёгиваться к одежде, но не к плитникам. Исправляю косячок.

### Чейнджлог
```yml
🆑Unchi
bugfix: Самодельные бронеплиты теперь цепляются только к плитоноскам.
/🆑
```
- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
