### PR TITLE
Fix хрю рекордс отображения фото

### DIFF
--- a/code/_helpers/icons.dm
+++ b/code/_helpers/icons.dm
@@ -698,6 +698,17 @@ lighting determines lighting capturing (optional), suppress_errors suppreses err
 	var/icon/cap = icon('icons/effects/96x96.dmi', "")
 	cap.Scale(range*32, range*32)
 	cap.Blend("#000", ICON_OVERLAY)
+
+	var/list/height_restore = list()
+	for(var/atom/A in atoms)
+		if(ishuman(A))
+			var/mob/living/carbon/human/H = A
+			if(H.height != HUMANHEIGHT_MEDIUM)
+				height_restore[H] = H.height
+				H.height = HUMANHEIGHT_MEDIUM
+				H.update_icons()
+				H.ImmediateOverlayUpdate()
+
 	for(var/atom/A in atoms)
 		if(A)
 			var/icon/img = getFlatIcon(A)
@@ -707,6 +718,12 @@ lighting determines lighting capturing (optional), suppress_errors suppreses err
 				var/xoff = (A.x - tx) * 32
 				var/yoff = (A.y - ty) * 32
 				cap.Blend(img, blendMode2iconMode(A.blend_mode),  A.pixel_x + xoff, A.pixel_y + yoff)
+
+
+	for(var/mob/living/carbon/human/H in height_restore)
+		H.height = height_restore[H]
+		H.update_icons()
+		H.ImmediateOverlayUpdate()
 
 	if(lighting)
 		for(var/atom/movable/lighting_overlay/lighting_overlay as anything in render_lighting)

--- a/code/modules/modular_computers/file_system/reports/crew_record.dm
+++ b/code/modules/modular_computers/file_system/reports/crew_record.dm
@@ -24,10 +24,18 @@ GLOBAL_VAR_AS(arrest_security_status, "Arrest")
 
 /datum/computer_file/report/crew_record/proc/load_from_mob(mob/living/carbon/human/H)
 	if(istype(H))
-		H.ImmediateOverlayUpdate()
 //[SIERRA-EDIT]
+		var/saved_height = H.height
+		if(saved_height != HUMANHEIGHT_MEDIUM)
+			H.height = HUMANHEIGHT_MEDIUM
+			H.update_icons()
+			H.ImmediateOverlayUpdate()
 		photo_front = getFlatIcon(H, SOUTH)
 		photo_side = getFlatIcon(H, WEST)
+		if(saved_height != HUMANHEIGHT_MEDIUM)
+			H.height = saved_height
+			H.update_icons()
+			H.ImmediateOverlayUpdate()
 	else
 		var/mob/living/carbon/human/dummy = new()
 		photo_front = getFlatIcon(dummy, SOUTH)


### PR DESCRIPTION
<!-- ЗДЕСЬ должно быть **подробное описание** того, что происходит в PR и зачем это нужно. PR не должен содержать изменений, о которых здесь ничего не сказано. -->
К сожаление бьенд не может применять дисплейсмент фильтры к картинкам. А сильно заморачивать серверную сторону тоже не хочу. Поэтому оптимальное решение. В хрю рекордсах и на фото у всех будет средний рост

<!-- ЗДЕСЬ нужно **привязать ишью**, которые относятся к PR'у в формате `close #1234` или `fixes #1234` - тогда они автоматически закроются вместе с PR. Можно написать `Затрагивает #1234, но не фиксит его`, если вы просто хотите упоминуть ишью, но не закрывать его. -->
close #0

<!-- ЗДЕСЬ нужно **расписать изменения** которые попадут в **чейнджлог**, формат - `prefix: краткое описание` -->
### Чейнджлог
```yml
🆑Lexanx
bugfix: Фикс Крю рекордс фото 
/🆑
```

<!--
  Честно заполняем галочки. Чем больше галочек, тем быстрее проверять Pull Request, соответственно он быстрее будет принят.
  Чтобы отметить - ставим `x` (икс) внутри квадратных скобочек вот так: `- [x] ...`.
  Галочки можно доставлять позже по мере окончания работы над PR'ом.
-->

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
