### PR TITLE
UI fixes

### DIFF
--- a/mods/RnD/code/program/camera.dm
+++ b/mods/RnD/code/program/camera.dm
@@ -6,14 +6,12 @@
 	var/obj/item/device/camera/computer/camera = new /obj/item/device/camera/computer
 	var/in_camera_mode = 0
 
-
 /obj/item/modular_computer/afterattack(atom/target as mob|obj|turf|area, mob/user as mob, flag)
-	. = ..()
+	..()
 	if(in_camera_mode)
 		hard_drive.create_file(camera.captureimagecomputer(target, usr))
 		to_chat(usr, SPAN_NOTICE("You took a photo of \the [target]."))
 		in_camera_mode = 0
-
 
 /obj/item/device/camera/computer/proc/captureimagecomputer(atom/target, mob/living/user, flag)
 	set_light(3, 3, light_color)
@@ -40,6 +38,7 @@
 		c.in_camera_mode = 0
 	else
 		c.in_camera_mode = 1
+		to_chat(usr, SPAN_NOTICE("Camera mode activated. Click on a target to take a photo."))
 
 /obj/item/photo/use_tool(obj/item/P, mob/living/user)
 	. = ..()

--- a/mods/RnD/code/program/designownloader.dm
+++ b/mods/RnD/code/program/designownloader.dm
@@ -23,6 +23,8 @@
 	var/server
 	var/selected_autolathe_category
 	var/show_desc_menu = FALSE
+	/// Current search query for filtering designs by name.
+	var/search_query = ""
 	usage_flags = PROGRAM_ALL
 	size = 6
 	available_on_ntnet = TRUE
@@ -36,6 +38,7 @@
 	download_netspeed = 0
 	downloaderror = ""
 	ui_header = "downloader_finished.gif"
+	search_query = ""
 
 /datum/computer_file/program/ntnetdesign/proc/begin_file_download(build_path, skill)
 	if(downloaded_file)
@@ -115,6 +118,14 @@
 	if(href_list["show_desc_menu"])
 		show_desc_menu = !show_desc_menu
 		return TOPIC_HANDLED
+	if(href_list["PRG_searchdesign"])
+		var/query = input(usr, "Enter design name:", "Search", search_query) as text|null
+		if(query != null)
+			search_query = lowertext(query)
+		return TOPIC_HANDLED
+	if(href_list["PRG_clearsearch"])
+		search_query = ""
+		return TOPIC_HANDLED
 	return TOPIC_NOACTION
 
 /datum/nano_module/program/computer_ntnetdesign
@@ -144,11 +155,14 @@
 	data["disk_used"] = program.computer.used_disk_capacity()
 	data["all_categories"] = get_category()
 	data["show_desc_menu"] = prog.show_desc_menu
+	data["search_query"] = prog.search_query
 
 	if((!prog.selected_autolathe_category || !(prog.selected_autolathe_category in data["all_categories"])) && LAZYLEN(SSresearch.design_categories_autolathe))
 		prog.selected_autolathe_category = SSresearch.design_categories_autolathe[2]
 
-	if(prog.selected_autolathe_category)
+	if(prog.search_query)
+		data["possible_designs"] = get_autolathe_designs_data(null, prog.search_query)
+	else if(prog.selected_autolathe_category)
 		data["selected_category"] = prog.selected_autolathe_category
 		data["possible_designs"] = get_autolathe_designs_data(prog.selected_autolathe_category)
 
@@ -156,15 +170,18 @@
 	data["downloadable_programs"] = all_entries
 
 	if(length(prog.downloads_queue) > 0)
-		var/list/queue = list() // Nanoui can't iterate through assotiative lists, so we have to do this
-		for(var/item in prog.downloads_queue)
-			queue += item
+		var/list/queue = list()
+		for(var/build_path in prog.downloads_queue)
+			var/datum/design/autolathe/D = SSresearch.get_autolathe_design_by_build_path(build_path)
+			queue += list(list(
+				"path" = build_path,
+				"name" = D ? D.shortname : build_path,
+			))
 		data["downloads_queue"] = queue
 
 	ui = SSnano.try_update_ui(user, src, ui_key, ui, data, force_open)
 	if (!ui)
 		ui = new(user, src, ui_key, "mods-ntnetdsgn_downloader.tmpl", "NTNet Download Design", 600, 700, state = state)
-		ui.auto_update_layout = 1
 		ui.set_initial_data(data)
 		ui.open()
 		ui.set_auto_update(1)
@@ -190,21 +207,26 @@
 
 
 
-/datum/nano_module/program/computer_ntnetdesign/proc/get_autolathe_designs_data(category)
+/datum/nano_module/program/computer_ntnetdesign/proc/get_autolathe_designs_data(category, search_query)
 	var/list/designs_list = list()
 	for(var/datum/design/autolathe/D in SSresearch.all_designs)
-		if(D.build_type)
-			var/cat = "Unspecified"
-			if(D.category)
-				cat = D.category
-			if(category in cat)
-				designs_list += list(list(
-					"build_path" =     D.build_path,
-					"name" =           D.shortname,
-					"desc" =           D.desc,
-					"size" =           D.file.size,
-					"materials" =      D.materials,
-				))
+		if(!D.build_type)
+			continue
+		if(search_query)
+			var/dname = D.shortname || D.name || ""
+			if(!findtext(dname, search_query))
+				continue
+		else if(category)
+			var/cat = D.category || "Unspecified"
+			if(!(category in cat))
+				continue
+		designs_list += list(list(
+			"build_path" =     D.build_path,
+			"name" =           D.shortname,
+			"desc" =           D.desc,
+			"size" =           D.file.size,
+			"materials" =      D.materials,
+		))
 	return designs_list
 
 /datum/computer_file/program/ntnetdesign/hacked

--- a/mods/RnD/code/program/designownloader.dm
+++ b/mods/RnD/code/program/designownloader.dm
@@ -126,6 +126,21 @@
 	if(href_list["PRG_clearsearch"])
 		search_query = ""
 		return TOPIC_HANDLED
+	if(href_list["PRG_downloadcategory"])
+		var/cat = href_list["PRG_downloadcategory"]
+		var/skill = usr.get_skill_value(SKILL_COMPUTER)
+		for(var/datum/design/autolathe/D in SSresearch.all_designs)
+			if(!D.build_type)
+				continue
+			var/dcat = D.category || "Unspecified"
+			if(!(cat in dcat))
+				continue
+			var/bp = D.build_path
+			if(!downloaded_file)
+				begin_file_download(bp, skill)
+			else if(!downloads_queue.Find(bp) && downloaded_file.filename != bp)
+				downloads_queue[bp] = skill
+		return TOPIC_HANDLED
 	return TOPIC_NOACTION
 
 /datum/nano_module/program/computer_ntnetdesign

--- a/nano/js/nano_state.js
+++ b/nano/js/nano_state.js
@@ -24,17 +24,87 @@ NanoStateClass.prototype.onBeforeUpdate = function (data) {
   data = NanoStateManager.executeBeforeUpdateCallbacks(data)
   return data
 }
+//[SIERRA-ADD]
+// Reconciles oldNode's children to match newNode's children without replacing the whole subtree.
+// Only nodes that actually changed are touched, preventing browser repaints on unchanged content.
+function nanoDiffNodes(oldNode, newNode) {
+  var oldChildren = oldNode.childNodes
+  var newChildren = newNode.childNodes
+  var i
 
+  // Update / add nodes
+  for (i = 0; i < newChildren.length; i++) {
+    var newChild = newChildren[i]
+    if (i >= oldChildren.length) {
+      oldNode.appendChild(newChild.cloneNode(true))
+      continue
+    }
+    var oldChild = oldChildren[i]
+    if (oldChild.nodeType !== newChild.nodeType) {
+      oldNode.replaceChild(newChild.cloneNode(true), oldChild)
+      continue
+    }
+    if (oldChild.nodeType === 3) { // Text node
+      if (oldChild.nodeValue !== newChild.nodeValue)
+        oldChild.nodeValue = newChild.nodeValue
+      continue
+    }
+    if (oldChild.nodeType === 1) { // Element node
+      if (oldChild.tagName !== newChild.tagName) {
+        oldNode.replaceChild(newChild.cloneNode(true), oldChild)
+        continue
+      }
+      nanoDiffAttrs(oldChild, newChild)
+      nanoDiffNodes(oldChild, newChild)
+    }
+  }
+
+  // Remove surplus old nodes (iterate backwards to avoid index shifting)
+  for (i = oldChildren.length - 1; i >= newChildren.length; i--)
+    oldNode.removeChild(oldChildren[i])
+}
+
+// Syncs attributes of oldEl to match newEl without touching unchanged ones.
+function nanoDiffAttrs(oldEl, newEl) {
+  var i, attr
+  for (i = oldEl.attributes.length - 1; i >= 0; i--) {
+    attr = oldEl.attributes[i]
+    if (!newEl.hasAttribute(attr.name))
+      oldEl.removeAttribute(attr.name)
+  }
+  for (i = 0; i < newEl.attributes.length; i++) {
+    attr = newEl.attributes[i]
+    if (oldEl.getAttribute(attr.name) !== attr.value)
+      oldEl.setAttribute(attr.name, attr.value)
+  }
+}
+
+// Renders newHtml into container using DOM diffing.
+// Falls back to innerHTML on first render (when container is empty).
+function nanoPatchHtml(container, newHtml) {
+  var el = container[0]
+  if (!el) return
+  if (!el.hasChildNodes()) {
+    el.innerHTML = newHtml
+    return
+  }
+  var scratch = document.createElement('div')
+  scratch.innerHTML = newHtml
+  nanoDiffNodes(el, scratch)
+}
+//[/SIERRA-ADD]
+
+//[SIERRA-EDIT] "nanoPatchHtml($("#uiLayout"), " теперь везде вместо  $("#uiHeaderContent").html(
 NanoStateClass.prototype.onUpdate = function (data) {
   try {
     if (!this.layoutRendered || (data['config'].hasOwnProperty('autoUpdateLayout') && data['config']['autoUpdateLayout'])){
-      $("#uiLayout").html(NanoTemplate.parse('layout', data))
+      nanoPatchHtml($("#uiLayout"), NanoTemplate.parse('layout', data))
       this.layoutRendered = true
     }
     if (!this.contentRendered || (data['config'].hasOwnProperty('autoUpdateContent') && data['config']['autoUpdateContent'])) {
-      $("#uiContent").html(NanoTemplate.parse('main', data))
+      nanoPatchHtml($("#uiContent"), NanoTemplate.parse('main', data))
       if (NanoTemplate.templateExists('layoutHeader'))
-        $("#uiHeaderContent").html(NanoTemplate.parse('layoutHeader', data))
+        nanoPatchHtml($("#uiHeaderContent"), NanoTemplate.parse('layoutHeader', data))
       this.contentRendered = true
     }
     if (NanoTemplate.templateExists('mapContent')) {
@@ -48,7 +118,7 @@ NanoStateClass.prototype.onUpdate = function (data) {
           })
         this.mapInitialised = true
       }
-      $("#uiMapContent").html(NanoTemplate.parse('mapContent', data))
+      nanoPatchHtml($("#uiMapContent"), NanoTemplate.parse('mapContent', data))
       if (data['config'].hasOwnProperty('showMap') && data['config']['showMap']) {
         $('#uiContent').addClass('hidden')
         $('#uiMapWrapper').removeClass('hidden')
@@ -59,15 +129,16 @@ NanoStateClass.prototype.onUpdate = function (data) {
       }
     }
     if (NanoTemplate.templateExists('mapHeader'))
-      $("#uiMapHeader").html(NanoTemplate.parse('mapHeader', data))
+      nanoPatchHtml($("#uiMapHeader"), NanoTemplate.parse('mapHeader', data))
     if (NanoTemplate.templateExists('mapFooter'))
-      $("#uiMapFooter").html(NanoTemplate.parse('mapFooter', data))
+      nanoPatchHtml($("#uiMapFooter"), NanoTemplate.parse('mapFooter', data))
   }
   catch(error) {
     alert('ERROR: An error occurred while rendering the UI: ' + error.message)
     return
   }
 }
+//[/SIERRA-EDIT]
 
 NanoStateClass.prototype.onAfterUpdate = function (data) {
   NanoStateManager.executeAfterUpdateCallbacks(data)

--- a/nano/templates/layout_modern.tmpl
+++ b/nano/templates/layout_modern.tmpl
@@ -34,9 +34,7 @@
 		</div>
 	</div>
 	<div id="computerButtons">
-		{{if !data.PC_showexitprogram}}
-			{{:helper.link('', 'image', {'PC_camera' : 1}, null, data.in_camera_mode ? 'yellowButton' : null)}}
-		{{/if}}
+		{{:helper.link('', 'image', {'PC_camera' : 1}, null, data.in_camera_mode ? 'yellowButton' : null)}}
 		{{if data.PC_showexitprogram}}
 			{{:helper.link('', 'minusthick', {'PC_minimize' : data.PC_activeprogram})}}
 			{{:helper.link('', 'closethick', {'PC_exit' : data.PC_activeprogram})}}

--- a/nano/templates/mods/ntnetdsgn_downloader.tmpl
+++ b/nano/templates/mods/ntnetdsgn_downloader.tmpl
@@ -1,106 +1,85 @@
-<i>Welcome to the design download utility. Please select which design you wish to download.</i><hr>
 {{if data.error}}
-	<h2>Download Error</h2>
-	<div class="itemLabel">
-		Information:
+<div class="block" style="margin:4px; padding:6px 8px; border-color:#ee0000">
+	<div class="item">
+		<div class="itemLabelWide" style="color:#ee0000"><b>Download Error</b></div>
+		<div class="itemContentNarrow" style="text-align:right">{{:helper.link("Dismiss", "refresh", {'PRG_reseterror':1})}}</div>
 	</div>
-	<div class="itemContent">
-		{{:data.error}}
+	<div class="item">
+		<div class="itemLabelWidest" style="font-size:10px">{{:data.error}}</div>
 	</div>
-	<div class="itemLabel">
-		Reset Program:
-	</div>
-	<div class="itemContent">
-		{{:helper.link("RESET", null, {'PRG_reseterror' : 1})}}
-	</div>
-	<hr>
+</div>
 {{/if}}
 
-	<h2>{{:data.downloadname ? 'Download Running' : 'No Downloads In Progress'}}</h2>
-	<i>{{:data.downloadname ? 'Please wait...' : 'Standing by...'}}</i>
+<div class="block" style="margin:4px; padding:6px 8px">
 	<div class="item">
-		<div class="itemLabel">
-			File name:
-		</div>
+		<div class="itemLabel" style="line-height:18px">Storage:</div>
 		<div class="itemContent">
-			{{:data.downloadname ? data.downloadname : 'N/A'}}
-		</div>
-		<div class="itemLabel">
-			File size:
-		</div>
-		<div class="itemContent">
-			{{:data.downloadname ? (data.downloadcompletion + 'GQ / ' + data.downloadsize + 'GQ') : 'N/A'}}
-		</div>
-		<div class="itemLabel">
-			Transfer Rate:
-		</div>
-		<div class="itemContent">
-			{{:data.downloadname ? data.downloadspeed : '0'}} GQ/s
-		</div>
-		<div class="itemLabel">
-			Download progress:
-		</div>
-		<div class="itemContent">
-			{{:helper.displayBar(data.downloadcompletion, 0, data.downloadname ? data.downloadsize : 0, 'good')}}
+			{{:helper.displayBar(data.disk_used, 0, data.disk_size, 'good')}}
+			<span style="font-size:10px; margin-left:4px">{{:data.disk_used}} / {{:data.disk_size}} GQ</span>
 		</div>
 	</div>
-
-	<br><hr>
-
-	<h2>Downloads Queue</h2>
+	{{if data.downloadname}}
 	<div class="item">
-	{{for data.downloads_queue}}
-		<div class="itemLabel">
-			{{:index + 1}}:
-		</div>
+		<div class="itemLabel" style="line-height:18px">Downloading:</div>
 		<div class="itemContent">
-			{{:value}}
-			{{:helper.link('', 'close', {'PRG_removequeued' : value})}}
+			{{:helper.displayBar(data.downloadcompletion, 0, data.downloadsize, 'good')}}
+			<span style="font-size:10px; margin-left:4px">{{:data.downloadname}} &mdash; {{:data.downloadcompletion}}/{{:data.downloadsize}} GQ &nbsp;@&nbsp;{{:data.downloadspeed}} GQ/s</span>
 		</div>
-	{{empty}}
-		<i>The queue is currently empty.</i>
-	{{/for}}
 	</div>
-	<br><hr>
-
-	<h2>Primary designs repository</h2>
-	<div class="itemLabel">
-		Hard drive:
-	</div>
-	<div class="itemContent">
-		{{:helper.displayBar(data.disk_used, 0, data.disk_size, 'good')}}
-		{{:data.disk_used}}GQ / {{:data.disk_size}}GQ
-	</div>
-
-	<br><hr>
-
-
-	<table>
-	<div style="display: flex;">
-	<br><tr>{{for data.all_categories}}
-		{{:helper.link(value, '', {'select_category' : value}, data.selected_category == value ? 'selected' : null)}}
-	{{/for}}
-	</div>
-	</table>
-	<table>
-	<div>
-	<tr>
-	<td><td>{{:helper.link("Toggle Description", '', {'show_desc_menu' : 1})}}</td></td></div>
-	<br>{{for data.possible_designs}}
-		<table>
-		<br><div style="border-bottom: 1px solid rgba(99, 99, 99, 8); margin-top: 8px;">
-			<div style="display: flex; justify-content: space-between;">
-				<tr><td>{{:helper.link( value.name, '', {'PRG_downloadfile' : value.build_path })}}
-					{{if data.show_desc_menu}}
-						<div class='item'>
-							<tr><td>{{:value.desc}}</td>
-						</div>
-					{{/if}}
-					<div align='right'>
-					<tr><td> File size <span class='white'>{{:value.size}} GQ </td>
-					</div>
+	{{/if}}
+	{{if data.downloads_queue}}
+	<div class="item">
+		<div class="itemLabel" style="line-height:18px">Queue:</div>
+		<div class="itemContent">
+			{{for data.downloads_queue}}
+			<div style="font-size:10px; line-height:180%">
+				{{:index + 1}}. {{:value.name}}&nbsp;{{:helper.link("×", "close", {'PRG_removequeued':value.path})}}
 			</div>
+			{{/for}}
 		</div>
-		</table>
-	{{/for}}
+	</div>
+	{{/if}}
+</div>
+
+<div class="block" style="margin:4px; padding:6px 8px">
+	<div class="item" style="margin-bottom:4px">
+		<div style="float:left">
+			{{:helper.link("Search", "search", {'PRG_searchdesign':1})}}
+			{{if data.search_query}}
+				<b style="color:#4f7529; margin:0 4px">{{:data.search_query}}</b>{{:helper.link("×", "close", {'PRG_clearsearch':1})}}
+			{{/if}}
+		</div>
+		<div style="float:right">
+			{{:helper.link(data.show_desc_menu ? "Hide desc" : "Show desc", data.show_desc_menu ? 'triangle-1-n' : 'triangle-1-s', {'show_desc_menu':1})}}
+		</div>
+	</div>
+
+	{{if !data.search_query}}
+	<div class="item" style="margin-bottom:4px; padding-bottom:4px; border-bottom:1px solid #40628a">
+		{{for data.all_categories}}
+			{{:helper.link(value, null, {'select_category':value}, data.selected_category == value ? 'selected' : null)}}
+		{{/for}}
+	</div>
+	{{/if}}
+
+	{{if data.possible_designs}}
+	<table style="width:100%; border-collapse:collapse; margin-top:2px">
+		{{for data.possible_designs}}
+		<tr class="candystripe" style="line-height:140%">
+			<td style="padding:2px 6px 2px 4px">
+				<b>{{:value.name}}</b>
+				{{if data.show_desc_menu && value.desc}}
+				<div style="color:#808080; font-size:10px; font-style:italic; font-weight:normal; margin-top:1px">{{:value.desc}}</div>
+				{{/if}}
+			</td>
+			<td style="padding:2px 20px 2px 6px; text-align:right; white-space:nowrap; font-size:10px; color:#808080; width:1%">{{:value.size}}&nbsp;GQ</td>
+			<td style="padding:2px 20px 2px 4px; text-align:right; white-space:nowrap; width:1%">{{:helper.link("&nbsp;&nbsp;", "arrowthickstop-1-s", {'PRG_downloadfile':value.build_path})}}</td>
+		</tr>
+		{{/for}}
 	</table>
+	{{else}}
+	<div style="text-align:center; color:#666; font-style:italic; padding:16px 0">
+		{{:data.search_query ? "No designs match your search." : "No designs in this category."}}
+	</div>
+	{{/if}}
+</div>

--- a/nano/templates/mods/ntnetdsgn_downloader.tmpl
+++ b/nano/templates/mods/ntnetdsgn_downloader.tmpl
@@ -50,7 +50,7 @@
 			{{/if}}
 		</div>
 		<div style="float:right">
-			{{:helper.link(data.show_desc_menu ? "Hide desc" : "Show desc", data.show_desc_menu ? 'triangle-1-n' : 'triangle-1-s', {'show_desc_menu':1})}}
+			{{if !data.search_query}}{{:helper.link("Download All", 'arrowthickstop-1-s', {'PRG_downloadcategory':data.selected_category})}}&nbsp;&nbsp;{{/if}}{{:helper.link(data.show_desc_menu ? "Hide desc" : "Show desc", data.show_desc_menu ? 'triangle-1-n' : 'triangle-1-s', {'show_desc_menu':1})}}
 		</div>
 	</div>
 


### PR DESCRIPTION
<!-- ЗДЕСЬ должно быть **подробное описание** того, что происходит в PR и зачем это нужно. PR не должен содержать изменений, о которых здесь ничего не сказано. -->

Раньше при каждом автообновлении UI браузер полностью заменял innerHTML контейнеров это вызывало видимое подергивание, особенно заметно было в шапке время, батарейка и прочее

При первом рендере используется обычный innerHTML 
При последующих обновлениях новый HTML парсится в scratch-элемент и сравнивается с текущим
В итоге браузер перерисовывает только изменившееся содержимое, а не все целиком.

<!-- ЗДЕСЬ нужно **привязать ишью**, которые относятся к PR'у в формате `close #1234` или `fixes #1234` - тогда они автоматически закроются вместе с PR. Можно написать `Затрагивает #1234, но не фиксит его`, если вы просто хотите упоминуть ишью, но не закрывать его. -->
close #3289

<!-- ЗДЕСЬ нужно **расписать изменения** которые попадут в **чейнджлог**, формат - `prefix: краткое описание` -->
### Чейнджлог
```yml
🆑Lexanx
bugfix: Возможность делать фото с КПК вновь работает
bugfix: Сделан DOM diffing, убирает раздражающее подергивание интерфейсов модульных компьютеров и не только.
rscadd: Переделан интерфейс программы скачки дизайнов, добавлен в неё поиск

/🆑
```

<!--
  Честно заполняем галочки. Чем больше галочек, тем быстрее проверять Pull Request, соответственно он быстрее будет принят.
  Чтобы отметить - ставим `x` (икс) внутри квадратных скобочек вот так: `- [x] ...`.
  Галочки можно доставлять позже по мере окончания работы над PR'ом.
-->

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
