### PR TITLE
Мобы теперь в состоянии попасть в упор

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -524,7 +524,7 @@
 		return null
 
 	var/obj/item/projectile/test/trace = new /obj/item/projectile/test(get_turf(firer)) //Making the test....
-	trace.firer = firer
+	trace.firer = firer //[SIERRA-ADD]
 
 	//Set the flags and pass flags to that of the real projectile...
 	if(!isnull(item_flags))

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -253,7 +253,8 @@
 	if(ismech(target_mob))
 		hit_zone = def_zone
 	else
-		hit_zone = get_zone_with_miss_chance(def_zone, target_mob, miss_modifier, ranged_attack=(distance > 1 || original != target_mob)) //if the projectile hits a target we weren't originally aiming at then retain the chance to miss
+		var/target_zone = def_zone ? def_zone : BP_CHEST
+		hit_zone = get_zone_with_miss_chance(target_zone, target_mob, miss_modifier, ranged_attack=(distance > 1 || original != target_mob)) //if the projectile hits a target we weren't originally aiming at then retain the chance to miss
 	//[SIERRA-ADD]
 
 	var/result = PROJECTILE_FORCE_MISS
@@ -523,6 +524,7 @@
 		return null
 
 	var/obj/item/projectile/test/trace = new /obj/item/projectile/test(get_turf(firer)) //Making the test....
+	trace.firer = firer
 
 	//Set the flags and pass flags to that of the real projectile...
 	if(!isnull(item_flags))


### PR DESCRIPTION
Исправлен баг со 100% промахом у мобов, которые стреляют на расстоянии в 2 тайла и меньше



<!-- ЗДЕСЬ нужно **расписать изменения** которые попадут в **чейнджлог**, формат - `prefix: краткое описание` -->
### Чейнджлог
```yml
🆑thekekman666
bugfix: Исправлена точность стреляющих мобов в упоре
/🆑
```

<!--
  Честно заполняем галочки. Чем больше галочек, тем быстрее проверять Pull Request, соответственно он быстрее будет принят.
  Чтобы отметить - ставим `x` (икс) внутри квадратных скобочек вот так: `- [x] ...`.
  Галочки можно доставлять позже по мере окончания работы над PR'ом.
-->

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
