### PR TITLE
Brain languages and AI core fix #35730

### DIFF
--- a/code/datums/mind/mind.dm
+++ b/code/datums/mind/mind.dm
@@ -89,7 +89,9 @@
 	if(new_character.mind)		//remove any mind currently in our new body's mind variable
 		new_character.mind.current = null
 
-	new_character.skillset.obtain_from_mob(current)	//handles moving skills over.
+	var/datum/skillset/S = new_character.skillset
+	if(S && !ispath(S))
+		S.obtain_from_mob(current)	//handles moving skills over.
 
 	current = new_character		//link ourself to our new body
 	new_character.mind = src	//and link our new body to ourself

--- a/code/modules/organs/internal/brain.dm
+++ b/code/modules/organs/internal/brain.dm
@@ -71,7 +71,7 @@
 		brainmob.real_name = H.real_name
 		brainmob.dna = H.dna.Clone()
 		brainmob.timeofhostdeath = H.timeofdeath
-		brainmob.languages = H.languages
+		brainmob.languages = H.languages.Copy()
 
 	if(H.mind)
 		H.mind.transfer_to(brainmob)

--- a/code/modules/organs/internal/species/fbp.dm
+++ b/code/modules/organs/internal/species/fbp.dm
@@ -182,6 +182,7 @@
 		persistantMind = owner.mind
 		if(owner.ckey)
 			ownerckey = owner.ckey
+		stored_mmi.brainmob.languages = owner.languages.Copy()
 	..()
 
 /obj/item/organ/internal/mmi_holder/proc/transfer_and_delete()

--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -610,6 +610,8 @@
 	if(M.brainmob && M.brainmob.mind)
 		M.brainmob.mind.transfer_to(target)
 
+	target.languages = M.brainmob.languages.Copy()
+
 /singleton/surgery_step/robotics/install_mmi/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	user.visible_message(SPAN_WARNING("[user]'s hand slips."), \
 	SPAN_WARNING("Your hand slips."))


### PR DESCRIPTION
Бот ниасилил, миррор ПРа Билдера на оффы

close #4852

* Adds an additional check for skillset transfer in order to fix ai core constuction - mind transfer there is called before skillset initialization, so its skippable now.

* Preserves languages in the brain upon its removal and transfers these languages upon FBP insertion. Makes it so that brains in MMI can still speak in their known languages, and so they will preserve all languages upon transfer to a new FBP body.

:cl: Builder13
bugfix: Languages are now preserved upon brain removal and a fix to AI core construction.
/:cl: