### PR TITLE
Фикс Rejuvenate для VR

### DIFF
--- a/mods/vr/code/mob.dm
+++ b/mods/vr/code/mob.dm
@@ -56,6 +56,11 @@
 /singleton/species/proc/get_vr(mob/living/carbon/human/H)
 	return ((H && H.isSynthetic()) ? "flashing a 'system occupied' glyph on their monitor" : show_vr)
 
+/mob/living/Destroy()
+	if (has_extension(src, /datum/extension/virtual_surrogate))
+		death()
+	..()
+
 /datum/mind/transfer_to(mob/living/new_character)
 	if (current && has_extension(current, /datum/extension/virtual_surrogate))
 		var/mob/M = SSvirtual_reality.virtual_mobs_to_occupants[current]

--- a/mods/vr/code/virtual_surrogate.dm
+++ b/mods/vr/code/virtual_surrogate.dm
@@ -54,7 +54,7 @@
 	set category = "VR"
 	set src = usr
 
-	rejuvenate()
+	revive()
 	if (ishuman(src))
 		var/mob/living/carbon/human/H = src
 		usr.client.prefs.copy_to(H) // Redo hair, augments, and limbs after rejuvenating


### PR DESCRIPTION
<!-- ЗДЕСЬ должно быть **подробное описание** того, что происходит в PR и зачем это нужно. PR не должен содержать изменений, о которых здесь ничего не сказано. -->
Исходный Rejuvenate не подходит для восстановления stump конечностей, он заменен на прок revive.

Теперь также выкидывает из виртуального тела обратно в реальное в случае удаления моба, например, через смену турфа. (удаление не должно происходить без задействования админских кнопок, но теперь и их тоже учитывает)

<!-- ЗДЕСЬ нужно **привязать ишью**, которые относятся к PR'у в формате `close #1234` или `fixes #1234` - тогда они автоматически закроются вместе с PR. Можно написать `Затрагивает #1234, но не фиксит его`, если вы просто хотите упоминуть ишью, но не закрывать его. -->
close #0

<!-- ЗДЕСЬ нужно **расписать изменения** которые попадут в **чейнджлог**, формат - `prefix: краткое описание` -->
### Чейнджлог
```yml
🆑Builder13
bugfix: Фикс Rejuvenate в VR и теперь в реальное тело должно выбрасывать даже в случае удаления виртуального тела. 
/🆑
```

<!--
  Честно заполняем галочки. Чем больше галочек, тем быстрее проверять Pull Request, соответственно он быстрее будет принят.
  Чтобы отметить - ставим `x` (икс) внутри квадратных скобочек вот так: `- [x] ...`.
  Галочки можно доставлять позже по мере окончания работы над PR'ом.
-->

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
