### PR TITLE
bugfix Зиппо не нагревает объекты

### DIFF
--- a/code/game/objects/items/weapons/lighter.dm
+++ b/code/game/objects/items/weapons/lighter.dm
@@ -166,8 +166,10 @@
 	user.visible_message(SPAN_CLASS("rose", "You hear a quiet click, as [user] shuts off [src] without even looking at what they're doing."))
 	playsound(src.loc, 'sound/items/zippo_close.ogg', 100, 1, -4)
 
-/obj/item/flame/lighter/zippo/use_after(atom/O, mob/living/user, click_parameters)
-	if (istype(O, /obj/structure/reagent_dispensers/fueltank) && !lit)
+/obj/item/flame/lighter/zippo/use_after(obj/O, mob/living/user, click_parameters)
+	if(lit && istype(O))
+		O.HandleObjectHeating(src, user, 700)
+	else if (istype(O, /obj/structure/reagent_dispensers/fueltank) && !lit)
 		O.reagents.trans_to_obj(src, max_fuel)
 		to_chat(user, SPAN_NOTICE("You refuel [src] from \the [O]"))
 		playsound(src.loc, 'sound/effects/refill.ogg', 50, 1, -6)


### PR DESCRIPTION
Исправляет баг с нагревом объектов /obj/item/flame/lighter/zippo который возник из-за добавления возможности его заправки от фуелтанка

close #4911 

### Чейнджлог
```yml
🆑AttHawk
bugfix: Зиппо не нагревает предметы
/🆑
```

<!--
  Честно заполняем галочки. Чем больше галочек, тем быстрее проверять Pull Request, соответственно он быстрее будет принят.
  Чтобы отметить - ставим `x` (икс) внутри квадратных скобочек вот так: `- [x] ...`.
  Галочки можно доставлять позже по мере окончания работы над PR'ом.
-->

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
