### PR TITLE
ВР радио

### DIFF
--- a/mods/vr/code/implants.dm
+++ b/mods/vr/code/implants.dm
@@ -36,7 +36,7 @@
 		to_chat(imp_in, SPAN_WARNING("Your implant refuses to activate. Wherever the VR space is hosted, it's gone to high alert and disabled connection."))
 		return
 	var/list/zone_list = list()
-	for(var/key in GLOB.vr_spawns)
+	for(var/key in GLOB.active_vr_areas)
 		zone_list.Add(key)
 	var/zone = input("Choose a zone.") as null|anything in zone_list
 	var/list/spawn_locs = SSvirtual_reality.get_vr_spawns(zone)
@@ -47,7 +47,8 @@
 		SPAN_WARNING("\The [imp_in] abruptly stiffens and goes unresponsive."),
 		SPAN_NOTICE("Your awareness rapidly shifts as your VR implant activates.")
 	)
-	SSvirtual_reality.create_virtual_mob(imp_in, imp_in.type, pick(spawn_locs))
+	var/mob/living/simulated_mob = SSvirtual_reality.create_virtual_mob(imp_in, imp_in.type, pick(spawn_locs))
+	SSvirtual_reality.after_mob_creation(simulated_mob, zone)
 
 /obj/item/implant/virtual_reality/emp_act(severity)
 	var/mob/living/carbon/human/C = imp_in

--- a/mods/vr/code/sierra_vr_override.dm
+++ b/mods/vr/code/sierra_vr_override.dm
@@ -372,6 +372,9 @@
 	for(var/obj/item/card/id/I in src)
 		I.access = real_access
 
+	if(istype(src, /mob/living/carbon/human))
+		SSvirtual_reality.recreate_headset(src)
+
 /mob/living/proc/spawn_vr_item()
 	set name = "Spawn VR item"
 	set desc = "Pick an item to spawn."
@@ -408,3 +411,39 @@
 			return
 
 		SSvirtual_reality.vr_spawn_menu(usr, available_obj, item_type)
+
+/obj/item/device/radio/receive_range(freq, level)
+	var/z_level = get_z(src)
+
+	if((z_level in GLOB.using_map.admin_levels) || (z_level in GLOB.using_map.vr_levels))
+		// station_levels check simplification
+		if(!(1 in level) && !(z_level in level))
+			return -1
+
+		if (!wires)
+			return -1
+		if (wires.IsIndexCut(WIRE_RECEIVE))
+			return -1
+		if(!listening)
+			return -1
+		if(freq in ANTAG_FREQS)
+			if(!(src.syndie))
+				return -1
+		if (!on)
+			return -1
+		if (!freq)
+			if (!listening)
+				return -1
+		else
+			var/accept = (freq==frequency && listening)
+			if (!accept)
+				for (var/ch_name in channels)
+					var/datum/radio_frequency/RF = secure_radio_connections[ch_name]
+					if (RF && RF.frequency==freq && (channels[ch_name]&FREQ_LISTENING))
+						accept = 1
+						break
+			if (!accept)
+				return -1
+
+		return canhear_range
+	. = ..()

--- a/mods/vr/code/virtual_reality.dm
+++ b/mods/vr/code/virtual_reality.dm
@@ -110,6 +110,45 @@ SUBSYSTEM_DEF(virtual_reality)
 
 	return cloned_atom
 
+/datum/controller/subsystem/virtual_reality/proc/recreate_headset(mob/living/carbon/human/M)
+	var/mob/living/carbon/human/occupant = SSvirtual_reality.virtual_mobs_to_occupants[M]
+
+	if(!occupant)
+		return
+
+	var/obj/item/device/radio/headset/R // headset of virtual mob
+	if(M.l_ear && istype(M.l_ear,/obj/item/device/radio))
+		R = M.l_ear
+	else if(M.r_ear && istype(M.r_ear,/obj/item/device/radio))
+		R = M.r_ear
+
+	var/obj/item/device/radio/headset/H // headset of real mob
+
+	if(occupant.l_ear && istype(occupant.l_ear,/obj/item/device/radio))
+		H = occupant.l_ear
+	else if(occupant.r_ear && istype(occupant.r_ear,/obj/item/device/radio))
+		H = occupant.l_ear
+
+	if(!H)
+		return
+
+	if(!R)
+		R = new H.type
+		M.equip_to_slot_or_del(R, slot_l_ear)
+
+	if(R)
+		if(istype(R, /obj/item/device/radio/headset))
+			for(var/channel_name in R.channels)
+				radio_controller.remove_object(R, radiochannels[channel_name])
+				R.secure_radio_connections[channel_name] = null
+			for(var/obj/key in R.encryption_keys)
+				qdel(key)
+			R.encryption_keys.Cut()
+			// clone the exact same keys that real body had
+			for(var/obj/item/device/encryptionkey/E in H.encryption_keys)
+				R.encryption_keys += new E.type(R)
+			R.recalculateChannels(TRUE)
+
 /datum/controller/subsystem/virtual_reality/proc/recursive_storage_copy(obj/item/storage/S, obj/item/storage/O)
 	for(var/obj/item/I in S.contents)
 		qdel(I)
@@ -236,6 +275,10 @@ SUBSYSTEM_DEF(virtual_reality)
 		simulated_mob.languages = new_occupant.languages.Copy()
 		simulated_mob.default_language = new_occupant.default_language
 	simulated_mob.lastarea = null
+
+	if(istype(simulated_mob, /mob/living/carbon/human))
+		recreate_headset(simulated_mob)
+
 	return simulated_mob
 
 /// Removes a mob from VR. Accepts both occupants and virtual mobs as a first argument.


### PR DESCRIPTION
<!-- ЗДЕСЬ должно быть **подробное описание** того, что происходит в PR и зачем это нужно. PR не должен содержать изменений, о которых здесь ничего не сказано. -->
За счет оверрайда, теперь рации принимают сообщения на админском уровне (тандердом) и в VR уровне. Сообщения принимает только с уровней Сиерры.

Также пофиксил выбор локаций для импланта - сделал его таким же как у VR пода.

И добавил пересоздание наушника при заходе в VR и при выборе экипировки, чтобы набор ключей был актуальным и чтобы наушник не пропадал при выборе экипировки в некоторых случаях.

<!-- ЗДЕСЬ нужно **привязать ишью**, которые относятся к PR'у в формате `close #1234` или `fixes #1234` - тогда они автоматически закроются вместе с PR. Можно написать `Затрагивает #1234, но не фиксит его`, если вы просто хотите упоминуть ишью, но не закрывать его. -->
close #0

<!-- ЗДЕСЬ нужно **расписать изменения** которые попадут в **чейнджлог**, формат - `prefix: краткое описание` -->
### Чейнджлог
```yml
🆑Builder13
rscadd: Рации в ВРе теперь принимают сообщения с Сиерры
bugfix: Пофиксил выбор локаций в ВР импланте
/🆑
```

<!--
  Честно заполняем галочки. Чем больше галочек, тем быстрее проверять Pull Request, соответственно он быстрее будет принят.
  Чтобы отметить - ставим `x` (икс) внутри квадратных скобочек вот так: `- [x] ...`.
  Галочки можно доставлять позже по мере окончания работы над PR'ом.
-->

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
